### PR TITLE
downgraded gradle 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.9.+'
+    classpath 'com.android.tools.build:gradle:0.8.+'
     classpath 'de.undercouch:gradle-download-task:0.+'
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip


### PR DESCRIPTION
Bringing the gradle versions back down as I cannot get the latest version to run in Android Studio correctly (also any version of AS above 0.4.3 doesnt seem to build as of current). 
