### PR TITLE
Modified Google IMA samples to handle seeking to the previous position

### DIFF
--- a/BasicIMASampleApp/src/main/java/com/brightcove/player/samples/ima/basic/MainActivity.java
+++ b/BasicIMASampleApp/src/main/java/com/brightcove/player/samples/ima/basic/MainActivity.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import android.view.ViewGroup;
 import com.brightcove.ima.GoogleIMAComponent;
 import com.brightcove.ima.GoogleIMAEventType;
+import com.brightcove.ima.GoogleIMAVideoAdPlayer;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventListener;
@@ -40,9 +41,12 @@ import java.util.Map;
 public class MainActivity extends BrightcovePlayer {
 
     private final String TAG = this.getClass().getSimpleName();
+    private static final String AD_POSITION = "adPosition";
 
     private EventEmitter eventEmitter;
     private GoogleIMAComponent googleIMAComponent;
+    private int adPosition;
+    private boolean adWasPlaying;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -80,7 +84,8 @@ public class MainActivity extends BrightcovePlayer {
 
         // Log whether or not instance state in non-null.
         if (savedInstanceState != null) {
-            Log.v(TAG, "Restoring saved position");
+            Log.v(TAG, "Restoring saved ad position");
+            adPosition = savedInstanceState.getInt(AD_POSITION);
         } else {
             Log.v(TAG, "No saved state");
         }
@@ -203,5 +208,58 @@ public class MainActivity extends BrightcovePlayer {
         // Create the Brightcove IMA Plugin and register the event emitter so that the plugin
         // can deal with video events.
         googleIMAComponent = new GoogleIMAComponent(brightcoveVideoView, eventEmitter);
+    }
+
+    @Override
+    protected void onStart() {
+        Log.v(TAG, "onStart: adPosition = " + adPosition);
+        super.onStart();
+
+        if ((googleIMAComponent != null) && (adPosition != -1)) {
+            GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+            googleIMAVideoAdPlayer.seekTo(adPosition);
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        Log.v(TAG, "onPause");
+        super.onPause();
+
+        GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+
+        if (googleIMAVideoAdPlayer.isPlaying()) {
+            googleIMAVideoAdPlayer.pauseAd();
+            adPosition = googleIMAVideoAdPlayer.getCurrentPosition();
+            adWasPlaying = true;
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        Log.v(TAG, "onResume");
+        super.onResume();
+
+        if (adWasPlaying) {
+            GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+            googleIMAVideoAdPlayer.start();
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle bundle) {
+        Log.v(TAG, "onSaveInstanceState: adPosition = " + adPosition);
+        bundle.putInt(AD_POSITION, adPosition);
+        super.onSaveInstanceState(bundle);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        Log.v(TAG, "onStop");
+
+        GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+        googleIMAVideoAdPlayer.stopPlayback();
+        adWasPlaying = false;
     }
 }

--- a/BasicIMAWidevineSampleApp/src/main/java/com/brightcove/player/samples/imawidevine/basic/MainActivity.java
+++ b/BasicIMAWidevineSampleApp/src/main/java/com/brightcove/player/samples/imawidevine/basic/MainActivity.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import com.brightcove.drm.widevine.WidevinePlugin;
 import com.brightcove.ima.GoogleIMAComponent;
 import com.brightcove.ima.GoogleIMAEventType;
+import com.brightcove.ima.GoogleIMAVideoAdPlayer;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventListener;
@@ -36,9 +37,12 @@ import java.util.Map;
 public class MainActivity extends BrightcovePlayer {
 
     private final String TAG = this.getClass().getSimpleName();
+    private static final String AD_POSITION = "adPosition";
 
     private EventEmitter eventEmitter;
     private GoogleIMAComponent googleIMAComponent;
+    private int adPosition;
+    private boolean adWasPlaying;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -201,5 +205,58 @@ public class MainActivity extends BrightcovePlayer {
         String deviceId = "device1234";
         String portalId = "brightcove";
         new WidevinePlugin(this, brightcoveVideoView, drmServerUri, deviceId, portalId);
+    }
+
+    @Override
+    protected void onStart() {
+        Log.v(TAG, "onStart: adPosition = " + adPosition);
+        super.onStart();
+
+        if ((googleIMAComponent != null) && (adPosition != -1)) {
+            GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+            googleIMAVideoAdPlayer.seekTo(adPosition);
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        Log.v(TAG, "onPause");
+        super.onPause();
+
+        GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+
+        if (googleIMAVideoAdPlayer.isPlaying()) {
+            googleIMAVideoAdPlayer.pauseAd();
+            adPosition = googleIMAVideoAdPlayer.getCurrentPosition();
+            adWasPlaying = true;
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        Log.v(TAG, "onResume");
+        super.onResume();
+
+        if (adWasPlaying) {
+            GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+            googleIMAVideoAdPlayer.start();
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle bundle) {
+        Log.v(TAG, "onSaveInstanceState: adPosition = " + adPosition);
+        bundle.putInt(AD_POSITION, adPosition);
+        super.onSaveInstanceState(bundle);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        Log.v(TAG, "onStop");
+
+        GoogleIMAVideoAdPlayer googleIMAVideoAdPlayer = googleIMAComponent.getVideoAdPlayer();
+        googleIMAVideoAdPlayer.stopPlayback();
+        adWasPlaying = false;
     }
 }


### PR DESCRIPTION
when resuming ad playback.

AdRulesIMASampleApp/src/main/java/com/brightcove/player/samples/ima/adrules/MainActivity.java
BasicIMASampleApp/src/main/java/com/brightcove/player/samples/ima/basic/MainActivity.java
BasicIMAWidevineSampleApp/src/main/java/com/brightcove/player/samples/imawidevine/basic/MainActivity.java
- Added AD_POSITION constant.
- Added adPosition and adWasPlaying variables to hold the state.
- Modified constructor to restore state.
- Added overrides for onStart(), onPause(), onResume(),
  onSaveInstanceState(), and onStop() to capture and restore the ad
  position.
