### PR TITLE
Android Studio Fixes

### DIFF
--- a/BasicAISWebViewSampleApp/build.gradle
+++ b/BasicAISWebViewSampleApp/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-    compile 'com.google.code.gson:gson:2.2.2'
-}

--- a/BasicAdobePassWebViewSampleApp/build.gradle
+++ b/BasicAdobePassWebViewSampleApp/build.gradle
@@ -1,4 +1,0 @@
-dependencies {
-    compile files("${rootProject.projectDir}/libs/android_accessenabler-1.7.2.jar")
-    compile 'com.google.code.gson:gson:2.2.2'
-}

--- a/BasicCastSampleApp/build.gradle
+++ b/BasicCastSampleApp/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'spoon'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.0.3"
 
     defaultConfig {
         minSdkVersion 11

--- a/BasicOnceUxSampleApp/build.gradle
+++ b/BasicOnceUxSampleApp/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-  compile "com.brightcove.player:android-onceux-plugin:${anpVersion}"
-}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ Provides sample apps for the Brightcove Player SDK and Plugins for Android.
 
 The Android sample app projects in this repository can be inserted directly into Android Studio and subsequently executed or simulated.  See below for detailed installation steps.
 
-This version of the sample apps supports the Brightcove SDK and plugins versioned 4.0.0 and higher.  The following sample apps are included:
+This version of the sample apps supports the latest Brightcove SDK and plugins.  The following sample apps are included:
+
+* [Ad Rules Google IMA Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "AdRulesIMASampleApp"): This app shows how to setup to use the Google IMA Plugin to play ads via Ad Rules. This version has been tested and works with v3 of the IMA SDK.
+
+* [Basic Akamai Identity Services Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicAISWebViewSampleApp"): This app shows how to configure an app to use the Brightcove native Android player with Akamai Identity Services.
+
+* [Basic AdobePass Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicAdobePassWebViewSampleApp"): This app shows how to configure an app to use the Brightcove native Android player with AdobePass.
+
+* [Basic Bundled Video Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicWidevineSampleApp"): This app shows how to play a video that is stored on the device for offline viewing.
+
+* [Basic Cast Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicCastSampleApp"): This add Google Chromecast with the Brightcove native Android player.
 
 * [Basic FreeWheel Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicFreeWheelSampleApp"): This app shows how to configure an app to use the Brightcove native Android player FreeWheel Plugin to play a video.
 
@@ -17,15 +27,15 @@ Note that in order to enable this sample app, you must independently obtain and 
 
 * [Basic Google IMA Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicIMASampleApp"): This app shows how to setup to use the Google IMA Plugin to play ads before, during and after a video. This version has been tested and works with v3 of the IMA SDK.
 
+* [Basic Google IMA Widevine Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicIMAWidevineSampleApp"): This app shows how to setup to use the Google IMA Plugin to play ads before, during and after a Widevine video. This version has been tested and works with v3 of the IMA SDK.
+
 * [Basic Omniture Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicOmnitureSampleApp"): This app shows how to configure an app to use the Brightcove native Android player Omniture Plugin to play a video.
 
 Note that in order to enable this sample app, you must independently obtain and install the file **adobe-adms.jar** into the top-level directory **libs/**.  Version 3.2.2 of the Adobe provided, non-free, jar file was used to test this sample app.
 
 * [Basic Widevine Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicWidevineSampleApp"): This app shows how to configure an app to use the Brightcove native Android player Widevine Plugin to play a video.
 
-* [Basic Bundled Video Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "BasicWidevineSampleApp"): This app shows how to play a video that is stored on the device for offline viewing.
-
-* [Ad Rules Google IMA Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "AdRulesIMASampleApp"): This app shows how to setup to use the Google IMA Plugin to play ads via Ad Rules. This version has been tested and works with v3 of the IMA SDK.
+* [HLS Player ID3 Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "HLSPlayerID3SampleApp"): This app shows how to use ID3 tags with the HLS player.
 
 * [HLS Player Sample App](http://docs.brightcove.com/en/video-cloud/brightcove-player-sdk-for-android/index.html "HLSPlayerSampleApp"): This app shows how to setup the HLS player to play.
 
@@ -34,11 +44,9 @@ Note that in order to enable this sample app, you must independently obtain and 
 
 By default, the sample apps will build with the most recent Brightcove Android Native Player version at build time.  To override this behavior with a specific version, create a file named **.gradle/gradle.properties** in your home directory and set the value of the property *anpVersion* to the desired version.  An invalid version will cause no sample app projects to be configured.
 
-All sample apps which have satisfied dependencies will run by default.  If you would like to explicitly disable a sample app, copy the associated boolean property from the **gradle.properties** top level file to **~/.gradle/gradle.properties** with a value of *false* instead of *true*.
-
 To install the sample apps into Android Studio follow these steps:
 
-1. Obtain and install the current version of [Android Studio](http://developer.android.com/sdk/installing/studio.html) using the provided on-line instructions,
+1. Obtain and install the latest version of [Android Studio](http://developer.android.com/sdk/installing/studio.html) using the provided on-line instructions,
 1. Configure Android Studio for Android versions from Android 10 to Android 19 (see Android Studio help for details),
 1. Invoke the new project wizard using the File menu if it is not presented by default,
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.8.+'
+    classpath 'com.android.tools.build:gradle:0.9.+'
     classpath 'de.undercouch:gradle-download-task:0.+'
   }
 }
@@ -13,7 +13,7 @@ buildscript {
 println "Using Android Native Player version: $anpVersion"
 
 project.ext {
-  imaAndroidSdkJarFileName = "ima-android-sdk-beta5.jar"
+  imaAndroidSdkJarFileName = "ima-android-sdk-beta6.jar"
 }
 
 // Automatically download the Google IMA third party zip file and
@@ -61,10 +61,10 @@ subprojects {
 
   android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.0.3"
 
     defaultConfig {
-      minSdkVersion 11
+      minSdkVersion 10
       targetSdkVersion 19
     }
   }
@@ -74,11 +74,30 @@ subprojects {
     compile "com.brightcove.player:android-sdk:$anpVersion@aar"
   }
 
+  if (project.name.contains('AdobePass')) {
+    dependencies {
+      compile files("${rootProject.projectDir}/libs/android_accessenabler-1.7.2.jar")
+      compile 'com.google.code.gson:gson:2.+'
+    }
+  }
+
+  if (project.name.contains('AIS')) {
+    dependencies {
+      compile 'com.google.code.gson:gson:2.+'
+    }
+  }
+
   if (project.name.contains('IMA')) {
     downloadIMA()
     dependencies {
       compile "com.brightcove.player:android-ima-plugin:${anpVersion}@aar"
       compile files("${rootProject.projectDir}/libs/" + imaAndroidSdkJarFileName)
+    }
+  }
+
+  if (project.name.contains('OnceUx')) {
+    dependencies {
+      compile "com.brightcove.player:android-onceux-plugin:${anpVersion}@aar"
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,21 +3,3 @@
 # Use this property to select the most recent Brightcove Android
 # Native Player version.
 anpVersion=4.+
-
-# Use these properties to enable/disable individual sample apps.
-runBasicFreewheelSampleApp=TRUE
-runBasicIMASampleApp=TRUE
-runBasicOmnitureSampleApp=TRUE
-runBasicWidevineSampleApp=TRUE
-runBasicBundledVideoSampleApp=TRUE
-runBasicIMAWidevineSampleApp=TRUE
-runAdRulesIMASampleApp=TRUE
-runBasicAdobePassWebViewSampleApp=TRUE
-runBasicAISWebViewSampleApp=TRUE
-runHLSPlayerSampleApp=TRUE
-runHLSPlayerID3SampleApp=TRUE
-runWebVTTSampleApp=TRUE
-runBasicCastSampleApp=TRUE
-runBasicOnceUxSampleApp=TRUE
-
-org.gradle.daemon=TRUE

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,44 +1,23 @@
+include ':AdRulesIMASampleApp'
+include ':BasicAISWebViewSampleApp'
+include ':BasicBundledVideoSampleApp'
+include ':BasicCastSampleApp'
+include ':BasicIMASampleApp'
+include ':BasicIMAWidevineSampleApp'
+include ':BasicOnceUxSampleApp'
+include ':BasicWidevineSampleApp'
+include ':HLSPlayerID3SampleApp'
+include ':HLSPlayerSampleApp'
+include ':WebVTTSampleApp'
 
-if (Boolean.valueOf("$runBasicFreewheelSampleApp") && freewheelDependenciesAreSatisfied())
-  include ':BasicFreeWheelSampleApp'
-if (Boolean.valueOf("$runBasicIMASampleApp"))
-  include ':BasicIMASampleApp'
-if (Boolean.valueOf("$runBasicIMAWidevineSampleApp"))
-  include ':BasicIMAWidevineSampleApp'
-if (Boolean.valueOf("$runBasicOmnitureSampleApp") && omnitureDependenciesAreSatisfied())
-  include ':BasicOmnitureSampleApp'
-if (Boolean.valueOf("$runBasicWidevineSampleApp"))
-  include ':BasicWidevineSampleApp'
-if (Boolean.valueOf("$runBasicBundledVideoSampleApp"))
-  include ':BasicBundledVideoSampleApp'
-if (Boolean.valueOf("$runAdRulesIMASampleApp"))
-  include ':AdRulesIMASampleApp'
-if (Boolean.valueOf("$runBasicAdobePassWebViewSampleApp") && adobepassDependenciesAreSatisfied())
-  include ':BasicAdobePassWebViewSampleApp'
-if (Boolean.valueOf("$runBasicAISWebViewSampleApp"))
-  include ':BasicAISWebViewSampleApp'
-if (Boolean.valueOf("$runHLSPlayerSampleApp"))
-  include ':HLSPlayerSampleApp'
-if (Boolean.valueOf("$runWebVTTSampleApp"))
-  include ':WebVTTSampleApp'
-if (Boolean.valueOf("$runBasicCastSampleApp"))
-  include ':BasicCastSampleApp'
-if (Boolean.valueOf("$runBasicOnceUxSampleApp"))
-  include ':BasicOnceUxSampleApp'
-if (Boolean.valueOf("$runHLSPlayerID3SampleApp"))
-  include ':HLSPlayerID3SampleApp'
+// AdobePass samples require android_accessenabler-1.7.2.jar to be
+// added to the libs folder.  This jar can be acquired from Adobe.
+//include ':BasicAdobePassWebViewSampleApp'
 
-boolean freewheelDependenciesAreSatisfied() {
-    File dep = file("${rootProject.projectDir}/libs/AdManager.jar")
-    return dep.exists()
-}
+// FreeWheel samples require AdManager.jar to be added to the libs
+// folder.  This jar can be acquired from FreeWheel.
+//include ':BasicFreeWheelSampleApp'
 
-boolean omnitureDependenciesAreSatisfied() {
-    File dep = file("${rootProject.projectDir}/libs/adobe-adms.jar")
-    return dep.exists()
-}
-
-boolean adobepassDependenciesAreSatisfied() {
-    File dep = file("${rootProject.projectDir}/libs/android_accessenabler-1.7.2.jar")
-    return dep.exists()
-}
+// Omniture samples require adobe-adms.jar to be added to the libs
+// folder.  This jar can be acquired from Adobe.
+//include ':BasicOmnitureSampleApp'


### PR DESCRIPTION
Using Android Studio 0.5.7, the samples should build successfully again.

BasicAISWebViewSampleApp/build.gradle
BasicAdobePassWebViewSampleApp/build.gradle
BasicOnceUxSampleApp/build.gradle
- Moved dependencies down into the root build.gradle.

BasicCastSampleApp/build.gradle
- Bumped the buildToolsVersion up to 19.0.3.

README.md
- Add descriptions for the missing samples.

build.gradle
- Bumped the gradle build tools version up to 0.9.+.
- Bumped the Google IMA version up to beta 6.
- Bumped the buildToolsVersion up to 19.0.3.
- Added dependency configuration for AdobePass, AIS, and OnceUX subprojects.

gradle.properties
- Removed the run*SampleApp flags as these were causing Android
  Studio issues.

gradle/wrapper/gradle-wrapper.properties
- Bumped the gradle version up to 1.11.

settings.gradle
- Removed the conditional logic and commented out the projects that
  have unsatisfied dependencies out of the box.  This helped to make
  Android Studio happy again.
