### PR TITLE
Use transitive dependencies.

### DIFF
--- a/BasicAISWebViewSampleApp/build.gradle
+++ b/BasicAISWebViewSampleApp/build.gradle
@@ -1,0 +1,3 @@
+dependencies { 
+  compile "com.brightcove.player:android-sdk:${anpVersion}"
+}

--- a/BasicBundledVideoSampleApp/build.gradle
+++ b/BasicBundledVideoSampleApp/build.gradle
@@ -1,3 +1,3 @@
-dependencies {
-
+dependencies { 
+  compile "com.brightcove.player:android-sdk:${anpVersion}"
 }

--- a/BasicFreeWheelSampleApp/build.gradle
+++ b/BasicFreeWheelSampleApp/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile "com.brightcove.player:android-freewheel-plugin:${anpVersion}@aar"
+    compile "com.brightcove.player:android-freewheel-plugin:${anpVersion}"
     compile files("${rootProject.projectDir}/libs/AdManager.jar")
 }

--- a/BasicOmnitureSampleApp/build.gradle
+++ b/BasicOmnitureSampleApp/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile "com.brightcove.player:android-omniture-plugin:${anpVersion}@aar"
+    compile "com.brightcove.player:android-omniture-plugin:${anpVersion}"
     compile files("${rootProject.projectDir}/libs/adobe-adms.jar")
 }

--- a/BasicOnceUxSampleApp/src/main/java/com/brightcove/player/samples/onceux/basic/MainActivity.java
+++ b/BasicOnceUxSampleApp/src/main/java/com/brightcove/player/samples/onceux/basic/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends BrightcovePlayer {
     //it's click through URL is.
 
     // The OnceUX plugin VMAP data URL.
-    private String onceUxVMAPDataUrl = "http://onceux.unicornmedia.com/now/ads/vmap/od/auto/95ea75e1-dd2a-4aea-851a-28f46f8e8195/43f54cc0-aa6b-4b2c-b4de-63d707167bf9/9b118b95-38df-4b99-bb50-8f53d62f6ef8??umtp=0";
+    private String onceUxAdDataUrl = "http://onceux.unicornmedia.com/now/ads/vmap/od/auto/95ea75e1-dd2a-4aea-851a-28f46f8e8195/43f54cc0-aa6b-4b2c-b4de-63d707167bf9/9b118b95-38df-4b99-bb50-8f53d62f6ef8??umtp=0";
     // Original from Criss: "http://onceux.unicornmedia.com/now/ads/vmap/od/auto/b11dbc9b-9d90-4edb-b4ab-769e0049209b/2455340c-8dcd-412e-a917-c6fadfe268c7/3a41c6e4-93a3-4108-8995-64ffca7b9106/bigbuckbunny?umtp=0";
 
     // The OnceUX plugin content URL.
@@ -69,7 +69,7 @@ public class MainActivity extends BrightcovePlayer {
         // On either event the plugin will continue playing the video.
         registerEventHandlers();
         OnceUxPlugin plugin = new OnceUxPlugin(this, brightcoveVideoView);
-        plugin.processServerData(onceUxVMAPDataUrl);
+        plugin.processVideo(onceUxAdDataUrl, onceUxContentUrl);
     }
 
     // Private instance methods
@@ -86,15 +86,6 @@ public class MainActivity extends BrightcovePlayer {
                 // Log the event and display a warning message (later)
                 Log.e(TAG, event.getType());
                 // TODO: throw up a stock Android warning widget.
-            }
-        });
-
-        eventEmitter.on(OnceUxEventType.AD_DATA_READY, new EventListener() {
-            @Override
-            public void processEvent(Event event) {
-                Log.i(TAG, "Ad data processing complete.  Starting video...");
-                brightcoveVideoView.setVideoPath(onceUxContentUrl);
-                brightcoveVideoView.start();
             }
         });
     }

--- a/WebVTTSampleApp/build.gradle
+++ b/WebVTTSampleApp/build.gradle
@@ -1,0 +1,3 @@
+dependencies { 
+  compile "com.brightcove.player:android-sdk:${anpVersion}"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,13 @@ buildscript {
 println "Using Android Native Player version: $anpVersion"
 
 project.ext {
-  imaAndroidSdkJarFileName = "ima-android-sdk-beta6.jar"
+  imaAndroidSdkJarFileName = "ima-android-sdk-beta5.jar"
 }
 
 // Automatically download the Google IMA third party zip file and
 // extract the jar to satisfy the dependency.
 def downloadIMA() {
-  def libs = "${rootProject.projectDir}/libs"
-  def libsdk = libs + '/' + imaAndroidSdkJarFileName
+  def libsdk = 'libs/' + imaAndroidSdkJarFileName
 
   // Conditionally download the Google IMA SDK during
   // configuration.  This step is done once.  The 'clean' task will not
@@ -33,7 +32,7 @@ def downloadIMA() {
 
     download {
       src 'https://dl.google.com/in-stream/google_sdk/android/v3/' + imaAndroidSdkJarFileName
-      dest file(libs)
+      dest file("${rootProject.projectDir}/libs/ima-android-sdk.jar")
     }
   }
 }
@@ -54,8 +53,11 @@ subprojects {
     }
     mavenLocal()
 
+    // This top level file repository will provide/contain third party
+    // dependencies which are either downloaded directly (not using a
+    // Maven repo) or installed manually for something like VisualOn.
     flatDir {
-      dirs '../libs'
+      dirs "${rootProject.projectDir}/libs"
     }
   }
 
@@ -71,7 +73,6 @@ subprojects {
 
   dependencies {
     compile 'com.android.support:appcompat-v7:+'
-    compile "com.brightcove.player:android-sdk:$anpVersion@aar"
   }
 
   if (project.name.contains('AdobePass')) {
@@ -90,20 +91,20 @@ subprojects {
   if (project.name.contains('IMA')) {
     downloadIMA()
     dependencies {
-      compile "com.brightcove.player:android-ima-plugin:${anpVersion}@aar"
+      compile "com.brightcove.player:android-ima-plugin:${anpVersion}"
       compile files("${rootProject.projectDir}/libs/" + imaAndroidSdkJarFileName)
     }
   }
 
   if (project.name.contains('OnceUx')) {
     dependencies {
-      compile "com.brightcove.player:android-onceux-plugin:${anpVersion}@aar"
+      compile "com.brightcove.player:android-onceux-plugin:${anpVersion}"
     }
   }
 
   if (project.name.contains('Widevine')) {
     dependencies {
-      compile "com.brightcove.player:android-widevine-plugin:${anpVersion}@aar"
+      compile "com.brightcove.player:android-widevine-plugin:${anpVersion}"
     }
 
     android {
@@ -115,7 +116,7 @@ subprojects {
 
   if (project.name.contains('HLS')) {
     dependencies {
-      compile "com.brightcove.player:android-hls-player:${anpVersion}@aar"
+      compile "com.brightcove.player:android-hls-player:${anpVersion}"
     }
   }
 
@@ -138,8 +139,8 @@ subprojects {
 
   if (project.name.contains('Cast')) {
     dependencies {
-      compile "com.brightcove.player:android-cast-plugin:${anpVersion}@aar"
-      compile 'com.google.sample.castcompanionlibrary:CastCompanionLibrary-android:+@aar'
+      compile "com.brightcove.player:android-cast-plugin:${anpVersion}"
+      compile 'com.google.sample.castcompanionlibrary:CastCompanionLibrary-android:+'
       compile 'com.google.android.gms:play-services:+'
       compile 'com.android.support:mediarouter-v7:+'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 12 11:32:38 EDT 2014
+#Thu May 08 12:27:52 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip


### PR DESCRIPTION
The technique of referencing Android libraries via an "@aar" suffix prevented transitive dependencies from being used correctly.  This change fixes that issue.

Files changed:

BasicAISWebViewSampleApp/build.gradle
BasicBundledVideoSampleApp/build.gradle
BasicFreeWheelSampleApp/build.gradle
BasicOmnitureSampleApp/build.gradle
WebVTTSampleApp/build.gradle
build.gradle
    \* Remove the "@aar" suffix on Android library dependency references.

BasicOnceUxSampleApp/src/main/java/com/brightcove/player/samples/onceux/basic/MainActivity.java
    \* Use the simplified interface for setting up the ad server and content server URL references.

gradle/wrapper/gradle-wrapper.properties
    \* Allow Android Studio to access Gradle sources.
