### PR TITLE
Upgraded the IMA SDK dependency and fixed the basic IMA sample app instrumentation test to get everything passing again.

### DIFF
--- a/AdRulesIMASampleApp/src/main/AndroidManifest.xml
+++ b/AdRulesIMASampleApp/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
         <activity
             android:name="com.brightcove.player.samples.ima.adrules.MainActivity"
             android:screenOrientation="unspecified"

--- a/AdRulesIMASampleApp/src/main/java/com/brightcove/player/samples/ima/adrules/MainActivity.java
+++ b/AdRulesIMASampleApp/src/main/java/com/brightcove/player/samples/ima/adrules/MainActivity.java
@@ -66,6 +66,10 @@ public class MainActivity extends BrightcovePlayer {
         catalog.findVideoByReferenceID("shark", new VideoListener() {
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
+
+                // Auto play: the GoogleIMAComponent will postpone
+                // playback until the Ad Rules are loaded.
+                brightcoveVideoView.start();
             }
 
             public void onError(String error) {
@@ -143,20 +147,7 @@ public class MainActivity extends BrightcovePlayer {
         // emitter so that the plugin can integrate with the SDK.
         googleIMAComponent = new GoogleIMAComponent(brightcoveVideoView, eventEmitter, true);
 
-        // After the video has been prepared, setup Ad Rules.
-        eventEmitter.on(EventType.DID_SET_VIDEO, new EventListener() {
-            @Override
-            public void processEvent(Event event) {
-                googleIMAComponent.initializeAdsRequests();
-            }
-        });
-
-        eventEmitter.on(GoogleIMAEventType.ADS_MANAGER_LOADED, new EventListener() {
-            @Override
-            public void processEvent(Event event) {
-                brightcoveVideoView.start();
-            }
-        });
+        // Calling GoogleIMAComponent.initializeAdsRequests() is no longer necessary.
     }
 
     @Override

--- a/AdRulesIMASampleApp/src/main/res/values/version.xml
+++ b/AdRulesIMASampleApp/src/main/res/values/version.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="google_play_services_version">4323000</integer>
+</resources>
+
+    <!--figure out how to get this from the google play services library TODO:bhnath-->

--- a/BasicIMASampleApp/src/main/AndroidManifest.xml
+++ b/BasicIMASampleApp/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
         <activity
             android:name="com.brightcove.player.samples.ima.basic.MainActivity"
             android:screenOrientation="unspecified"

--- a/BasicIMASampleApp/src/main/res/values/version.xml
+++ b/BasicIMASampleApp/src/main/res/values/version.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="google_play_services_version">4323000</integer>
+</resources>
+
+    <!--figure out how to get this from the google play services library TODO:bhnath-->

--- a/BasicIMAWidevineSampleApp/src/main/AndroidManifest.xml
+++ b/BasicIMAWidevineSampleApp/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
         <activity
             android:name="com.brightcove.player.samples.imawidevine.basic.MainActivity"
             android:screenOrientation="unspecified"

--- a/BasicIMAWidevineSampleApp/src/main/res/values/version.xml
+++ b/BasicIMAWidevineSampleApp/src/main/res/values/version.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="google_play_services_version">4323000</integer>
+</resources>
+
+    <!--figure out how to get this from the google play services library TODO:bhnath-->

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 println "Using Android Native Player version: $anpVersion"
 
 project.ext {
-  imaAndroidSdkJarFileName = "ima-android-sdk-beta5.jar"
+  imaAndroidSdkJarFileName = "ima-android-sdk-beta7.jar"
 }
 
 // Automatically download the Google IMA third party zip file and


### PR DESCRIPTION
AdRulesIMASampleApp/src/main/AndroidManifest.xml
BasicIMASampleApp/src/main/AndroidManifest.xml
BasicIMAWidevineSampleApp/src/main/AndroidManifest.xml
- Added meta-data required by Google Player Services, which is now
  required by the IMA SDK.

AdRulesIMASampleApp/src/main/java/com/brightcove/player/samples/ima/adrules/MainActivity.java
- Modified auto-play implementation by removing the
  ADS_MANAGER_LOADED listener and just calling start() from the
  Catalog onVideo() callback.
- Removed the DID_SET_VIDEO listener, because
  initializeAdsRequests() is now called automatically by the
  GoogleIMAComponent.

AdRulesIMASampleApp/src/main/res/values/version.xml
BasicIMASampleApp/src/main/res/values/version.xml
BasicIMAWidevineSampleApp/src/main/res/values/version.xml
- Initial checkin.

BasicIMASampleApp/src/androidTest/java/com/brightcove/player/samples/ima/basic/test/MainActivityTest.java
- Modified the DID_START_AD listener to all the tracking.
- Modified the DID_COMPLETE_AD listener to no longer do any tracking.
- Modified testAdPauseResume() to no longer fork a new Thread,
  because the IMA SDK uses a WebView and only the Thread which
  created the WebView can make calls on it.

build.gradle
- Upgraded the IMA SDK dependency to v3beta7.
