### PR TITLE
quick fix to get the build building again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.11.+'
+    classpath 'com.android.tools.build:gradle:0.10.+'
     classpath 'de.undercouch:gradle-download-task:0.+'
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip


### PR DESCRIPTION
This quick revert should allow for the repo to build again. However, it seems that the releases are auto pulled with the anpVersion string 4.+, instead of the snapshots for internal purposes. This will need to be looked at further. When the snapshot version is forced, we see normal internal behavior. 
