### PR TITLE
Fix Team City regression test breakage.

### DIFF
--- a/BasicOnceUxSampleApp/build.gradle
+++ b/BasicOnceUxSampleApp/build.gradle
@@ -1,0 +1,3 @@
+// Disable running connectedCheck on the OnceUxSampleApp as it is
+// configured to run 'uiautomator' instead of integration tests.
+task connectedCheck(overwrite: true) {}


### PR DESCRIPTION
## Rationale:

Adding **uiautomator** resulted in breakage on Team City regression testing.  The issue is that the BasicOnceUxSampleApp now runs UIAutomator tests rather than integration tests (which have been moved to the ANP build).  But **uiatomator** now is driven by _Ant_ rather than _Gradle_ and attempting to use _Gradle_ to run the **connectedCheck** task will result in compilation errors and a runtime exception.  The fix is to disable the task by redefining it to be a no-op.
## Changed files:

BasicOnceUxSampleApp/build.gradle
- Redefine the **connectedCheck** task.
