### PR TITLE
remove default exoplayer build in gradle settings. add information

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,10 @@ include ':HLSPlayerID3SampleApp'
 include ':HLSPlayerSampleApp'
 include ':WebVTTSampleApp'
 include ':DFXPClosedCaptioningSampleApp'
-include ':ExoPlayerSampleApp'
+
+// The ExoPlayer integration in the Brightcove Native Player SDK for Android
+// is still in extensive internal testing. This is a placeholder.
+// include ':ExoPlayerSampleApp'
 
 // FreeWheel samples require AdManager.jar to be added to the libs
 // folder.  This jar can be acquired from FreeWheel.


### PR DESCRIPTION
Since our ExoPlayer implementation is not meant for prime time just yet, remove the build of the demo app by default. 