### PR TITLE
Update the targetSdkVersion to 23, to better support Android Marshmallow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ configure(subprojects.findAll {it.name.endsWith('SampleApp')}) {
 
     defaultConfig {
       minSdkVersion 10
-      targetSdkVersion 22
+      targetSdkVersion 23
     }
 
     signingConfigs {


### PR DESCRIPTION
Testing:
1. With targetSdkVersion unchanged, build, deploy and run sample apps in Android Studio, to a Marshmallow device. Note that there is a compatibility warning displayed.
2. With targetSdkVersion changed from 22 to 23, build, deploy and run samples apps in Android Studio, to a Marshmallow device. Verify that there is no compatibility warning.
3. Verify that apps build and deploy to a 4.4.4 device with the change to targetSdkVersion.

Apps tested include:
All brightcove-exoplayer apps
brightcove-hls/BasicSampleApp
AdRulesIMASampleApp
WebVTTSampleApp