### PR TITLE
Remove redundant resource definition.

### DIFF
--- a/BasicCastSampleApp/src/main/res/values/version.xml
+++ b/BasicCastSampleApp/src/main/res/values/version.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="google_play_services_version">8115000</integer>
-</resources>


### PR DESCRIPTION
`google_play_services_version` must be defined in Google Play Service.
Client app should not override.

With this declaration, App crashes with following message:

```
Caused by: java.lang.IllegalStateException: The meta-data tag in your app's AndroidManifest.xml does not have the right value.  Expected 8298000 but found 8115000.  You must have the following declaration within the <application> element:     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
```