### PR TITLE
Removed the include for brightcove-exoplayer/FreeWheelSampleApp from settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,6 @@ if (freewheelDependenciesAreSatisfied()) {
     include ':BasicFreeWheelSampleApp'
     include ':BasicFreeWheelWidevineSampleApp'
     include ':brightcove-hls:FreeWheelSampleApp'
-    include ':brightcove-exoplayer:FreeWheelSampleApp'
     include ':brightcove-exoplayer:FreeWheelWidevineModularSampleApp'
 }
 


### PR DESCRIPTION
This sample app no longer exists, and a command-line build failure was the result.
Update:
This reference to brightcove-exoplayer/FreeWheelSampleApp also causes a Gradle sync failure in Android Studio.

Testing:
Ran `./gradlew clean build` at the command line, and verified a successful outcome.
In Android Studio, did a Gradle sync, and verified a successful outcome.