### PR TITLE
OfflinePlaybackSampleApp update

### DIFF
--- a/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
+++ b/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
@@ -104,6 +104,7 @@ public class MainActivity extends BrightcovePlayer {
         super.onStart();
         ConnectivityMonitor.getInstance(this).addListener(connectivityListener);
         catalog.addDownloadEventListener(downloadEventListener);
+        updateVideoList();
     }
 
     @Override


### PR DESCRIPTION
Added change to update the video list in the Activity onStart for OfflinePlaybackSampleApp.
This fixes an issue when the app will have an empty screen after closing the app with the back button and then relaunching it.