### PR TITLE
Updated ExoPlayer 2 samples gradle.properties to use 6.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 
 # Use this property to select the most recent Brightcove Android
 # Native Player version.
-anpVersion=6.2.1
+anpVersion=6.2.2


### PR DESCRIPTION
I renamed the branch after I realized that we need to promote this change to both the Exo1 and Exo2 versions of the samples.