### PR TITLE
Update FreeWheel Sample Apps to use AdManager 6.23.0 - master branch

### DIFF
--- a/brightcove-exoplayer/FreeWheelSampleApp/src/main/java/com/brightcove/player/samples/exoplayer/freewheel/basic/MainActivity.java
+++ b/brightcove-exoplayer/FreeWheelSampleApp/src/main/java/com/brightcove/player/samples/exoplayer/freewheel/basic/MainActivity.java
@@ -77,7 +77,7 @@ public class MainActivity extends BrightcovePlayer {
             public void processEvent(Event event) {
                 @SuppressWarnings("unchecked")
                 List<ISlot> slots = (List<ISlot>) event.properties.get(FreeWheelController.AD_SLOTS_KEY);
-                ViewGroup adView = (ViewGroup) findViewById(R.id.ad_frame);
+                ViewGroup adView = findViewById(R.id.ad_frame);
 
                 // Clean out any previous display ads
                 for (int i = 0; i < adView.getChildCount(); i++) {
@@ -103,11 +103,11 @@ public class MainActivity extends BrightcovePlayer {
                 // This overrides what the plugin does by default for setVideoAsset() which is to pass in currentVideo.getId().
                 VideoAssetConfiguration fwVideoAssetConfiguration = new VideoAssetConfiguration(
                         "3pqa_video",
-                        adConstants.ID_TYPE_CUSTOM(),
+                        IConstants.IdType.CUSTOM,
                         //FW uses their duration as seconds; Android is in milliseconds
                         video.getDuration()/1000,
-                        adConstants.VIDEO_ASSET_DURATION_TYPE_EXACT(),
-                        adConstants.VIDEO_ASSET_AUTO_PLAY_TYPE_ATTENDED());
+                        IConstants.VideoAssetDurationType.EXACT,
+                        IConstants.VideoAssetAutoPlayType.ATTENDED);
                 adRequestConfiguration.setVideoAssetConfiguration(fwVideoAssetConfiguration);
 
                 NonTemporalSlotConfiguration companionSlot = new NonTemporalSlotConfiguration("300x250slot", null, 300, 250);

--- a/brightcove-exoplayer/FreeWheelWidevineModularSampleApp/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/basic/MainActivity.java
+++ b/brightcove-exoplayer/FreeWheelWidevineModularSampleApp/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/basic/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends BrightcovePlayer {
             public void processEvent(Event event) {
                 @SuppressWarnings("unchecked")
                 List<ISlot> slots = (List<ISlot>) event.properties.get(FreeWheelController.AD_SLOTS_KEY);
-                ViewGroup adView = (ViewGroup) findViewById(R.id.ad_frame);
+                ViewGroup adView = findViewById(R.id.ad_frame);
 
                 // Clean out any previous display ads
                 for (int i = 0; i < adView.getChildCount(); i++) {
@@ -115,11 +115,11 @@ public class MainActivity extends BrightcovePlayer {
                 // This overrides what the plugin does by default for setVideoAsset() which is to pass in currentVideo.getId().
                 VideoAssetConfiguration fwVideoAssetConfiguration = new VideoAssetConfiguration(
                         "3pqa_video",
-                        adConstants.ID_TYPE_CUSTOM(),
+                        IConstants.IdType.CUSTOM,
                         //FW uses their duration as seconds; Android is in milliseconds
                         video.getDuration()/1000,
-                        adConstants.VIDEO_ASSET_DURATION_TYPE_EXACT(),
-                        adConstants.VIDEO_ASSET_AUTO_PLAY_TYPE_ATTENDED());
+                        IConstants.VideoAssetDurationType.EXACT,
+                        IConstants.VideoAssetAutoPlayType.ATTENDED);
                 adRequestConfiguration.setVideoAssetConfiguration(fwVideoAssetConfiguration);
 
                 NonTemporalSlotConfiguration companionSlot = new NonTemporalSlotConfiguration("300x250slot", null, 300, 250);

--- a/brightcove-mediaplayer/BasicFreeWheelSampleApp/src/main/java/com/brightcove/player/samples/freewheel/basic/MainActivity.java
+++ b/brightcove-mediaplayer/BasicFreeWheelSampleApp/src/main/java/com/brightcove/player/samples/freewheel/basic/MainActivity.java
@@ -6,12 +6,12 @@ import android.view.ViewGroup;
 
 import com.brightcove.freewheel.controller.FreeWheelController;
 import com.brightcove.freewheel.event.FreeWheelEventType;
+import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.PlaylistListener;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventListener;
 import com.brightcove.player.event.EventType;
-import com.brightcove.player.edge.Catalog;
-import com.brightcove.player.edge.PlaylistListener;
 import com.brightcove.player.model.Playlist;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
@@ -86,7 +86,7 @@ public class MainActivity extends BrightcovePlayer {
             public void processEvent(Event event) {
                 @SuppressWarnings("unchecked")
                 List<ISlot> slots = (List<ISlot>) event.properties.get(FreeWheelController.AD_SLOTS_KEY);
-                ViewGroup adView = (ViewGroup) findViewById(R.id.ad_frame);
+                ViewGroup adView = findViewById(R.id.ad_frame);
 
                 // Clean out any previous display ads
                 for (int i = 0; i < adView.getChildCount(); i++) {
@@ -118,11 +118,11 @@ public class MainActivity extends BrightcovePlayer {
                 // This overrides what the plugin does by default for setVideoAsset() which is to pass in currentVideo.getId().
                 VideoAssetConfiguration fwVideoAssetConfiguration = new VideoAssetConfiguration(
                         "3pqa_video",
-                        adConstants.ID_TYPE_CUSTOM(),
+                        IConstants.IdType.CUSTOM,
                         //FW uses their duration as seconds; Android is in milliseconds
                         video.getDuration()/1000,
-                        adConstants.VIDEO_ASSET_DURATION_TYPE_EXACT(),
-                        adConstants.VIDEO_ASSET_AUTO_PLAY_TYPE_ATTENDED());
+                        IConstants.VideoAssetDurationType.EXACT,
+                        IConstants.VideoAssetAutoPlayType.ATTENDED);
                 adRequestConfiguration.setVideoAssetConfiguration(fwVideoAssetConfiguration);
 
                 NonTemporalSlotConfiguration companionSlot = new NonTemporalSlotConfiguration("300x250slot", null, 300, 250);

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 
 # Use this property to select the most recent Brightcove Android
 # Native Player version.
-anpVersion=6.2.2
+anpVersion=6.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 
 # Use this property to select the most recent Brightcove Android
 # Native Player version.
-anpVersion=6.2.1
+anpVersion=6.2.2


### PR DESCRIPTION
Note: Do not merge until after the v6.3.0 Android SDK release.
Tested with the following apps in release mode:
brightcove-exoplayer/BasicSampleApp
brightcove-exoplayer/AppCompatActivitySampleApp
brightcove-exoplayer/AdRulesIMASampleApp
brightcove-exoplayer/AdRulesIMAWidevineModularSampleApp
brightcove-exoplayer/FreeWheelSampleApp
brightcove-exoplayer/FreeWheelWidevineModularSampleApp
brightcove-mediaplayer/BasicFreeWheelSampleApp
