### PR TITLE
Added a Brightcove account with an Ad Config Id for the SSAI sample app

### DIFF
--- a/brightcove-exoplayer/BasicSsaiSampleApp/src/main/res/values/strings.xml
+++ b/brightcove-exoplayer/BasicSsaiSampleApp/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">BasicSsaiSampleApp</string>
+
+    <string name="sdk_demo_account">5420904993001</string>
+    <string name="sdk_demo_policy_key">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
+    <string name="video_id">6031901107001</string>
 </resources>


### PR DESCRIPTION
The Ad Config Id will return a video with the following ad information:

- 1 pre-roll with a companion.
- 1 mid-roll at 1m, with an skip offset of 5 seconds.
- 1 pre-roll
