### PR TITLE
Removed extra '>' in AppCompatActivitySampleApp manifest

### DIFF
--- a/brightcove-exoplayer/AppCompatActivitySampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer/AppCompatActivitySampleApp/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
             android:screenOrientation="unspecified"
             android:banner="@drawable/tv_banner"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Removed the extra '>' in the AppCompatActivitySampleApp manifest, causing problems in a higher gradle version.