### PR TITLE
Added the ACCESS_NETWORK_STATE permission for downloads on sleeping devices

### DIFF
--- a/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           package="com.brightcove.player.samples.offlineplayback">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
This setting enabled downloads to continue while the device was locked.