### PR TITLE
Disable companions in the TV UI for IMA VAST Sample App

### DIFF
--- a/brightcove-exoplayer/BasicIMAVASTSampleApp/src/main/java/com/brightcove/player/samples/ima/basic/MainActivity.java
+++ b/brightcove-exoplayer/BasicIMAVASTSampleApp/src/main/java/com/brightcove/player/samples/ima/basic/MainActivity.java
@@ -154,7 +154,7 @@ public class MainActivity extends BrightcovePlayer {
             // Create a container object for the ads to be presented.
             AdDisplayContainer container = googleIMAComponent.getAdDisplayContainer();
 
-            if (container != null) {
+            if (container != null && !brightcoveVideoView.getBrightcoveMediaController().isTvMode) {
                 // Populate the container with the companion ad slots.
                 ArrayList<CompanionAdSlot> companionAdSlots = new ArrayList<>();
                 CompanionAdSlot companionAdSlot = sdkFactory.createCompanionAdSlot();


### PR DESCRIPTION
Found this while testing a bug.
If we're in TV mode, prevent the display of companion ads (in the sample, they block the player controls)