### PR TITLE
Update Android SDK to v8.4.2

### DIFF
--- a/brightcove-exoplayer/FreeWheelSampleApp/src/main/java/com/brightcove/player/samples/exoplayer/freewheel/basic/MainActivity.java
+++ b/brightcove-exoplayer/FreeWheelSampleApp/src/main/java/com/brightcove/player/samples/exoplayer/freewheel/basic/MainActivity.java
@@ -11,6 +11,7 @@ import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventListener;
+import com.brightcove.player.model.DeliveryType;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@
 # Native Player version.
 android.enableJetifier=true
 android.useAndroidX=true
-anpVersion=8.4.1
+anpVersion=8.4.2
 org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -XX:MaxMetaspaceSize=4g


### PR DESCRIPTION
Update the Brightcove Android SDK to v8.4.2.

This also imports the `DeliveryType` class into the Freewheel Sample app.