### PR TITLE
Migrate multidex dependency to use androidx.multidex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ configure(subprojects.findAll {it.name.endsWith('SampleApp')}) {
 
   dependencies {
     implementation "com.brightcove.player:android-sdk:${anpVersion}"
-    implementation "com.android.support:multidex:${MULTIDEX_VERSION}"
+    implementation "androidx.multidex:multidex:${MULTIDEX_VERSION}"
   }
 
   if (project.name.contains('IMA')) {


### PR DESCRIPTION
Replace the multidex dependency from using `com.android.support:multidex` to `androix.multidex:multidex`