### PR TITLE
AND-3079 Fix onConfigurationChanged callback not being called

### DIFF
--- a/brightcove-exoplayer-kotlin/AudioOnlySampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/AudioOnlySampleApp/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".AudioOnlyActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize"
             android:label="@string/app_name"
             android:theme="@style/Theme.AudioOnlySample.NoActionBar">
             <intent-filter>

--- a/brightcove-exoplayer-kotlin/BasicIMAVASTSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/BasicIMAVASTSampleApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Base.Theme.BasicIMAVASTSampleApp">
         <activity
             android:name=".BasicIMAVASTSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/BasicSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/BasicSampleApp/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         tools:targetApi="31">
         <activity
             android:name=".BasicSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/BasicSsaiPALSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/BasicSsaiPALSampleApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Base.Theme.BasicSsaiSample">
         <activity
             android:name=".BasicSsaiPALSampleAppActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/BasicSsaiSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/BasicSsaiSampleApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Base.Theme.BasicSsaiSample">
         <activity
             android:name=".BasicSsaiSampleAppActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/BumperSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/BumperSampleApp/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         tools:targetApi="31">
         <activity
             android:name=".BumperSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/LiveSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/LiveSampleApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Base.Theme.LiveSampleApp">
         <activity
             android:name=".LiveSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/TextureViewSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/TextureViewSampleApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Base.Theme.TextureViewSample">
         <activity
             android:name=".TextureViewSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/brightcove-exoplayer-kotlin/VideoListSampleApp/src/main/AndroidManifest.xml
+++ b/brightcove-exoplayer-kotlin/VideoListSampleApp/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/Theme.videoList">
         <activity
             android:name=".VideoListSampleActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
fix onConfigurationChanged callback not being called: add missing attribute to some apps' activities - android:configChanges="orientation|screenSize"