### PR TITLE
fix: correctly set rent duration for offline playback

### DIFF
--- a/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt
+++ b/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt
@@ -460,13 +460,10 @@ class MainActivity : BrightcovePlayer() {
         DatePickerFragment().setTitle("Select Rental Expiry Date").setListener(
             object : DatePickerFragment.Listener {
                 override fun onDateSelected(expiryDate: Date) {
-                    // Extend the playDuration value to the video duration plus an additional small amount to account for:
-                    // - Loading the video into the player (which starts the playDuration clock)
-                    // - Starting playback in a manual-start player
-                    var playDuration: Long = video.durationLong + PLAYDURATION_EXTENSION
-                    if (playDuration == 0L) {
-                        playDuration = DEFAULT_RENTAL_PLAY_DURATION
-                    }
+                    // Use the default rental play duration for offline playback license.
+                    // This determines how long the content can be consumed after download,
+                    // not the actual video duration.
+                    val playDuration: Long = DEFAULT_RENTAL_PLAY_DURATION
 
                     val httpRequestConfigBuilder = HttpRequestConfig.Builder()
                     httpRequestConfigBuilder.setBrightcoveAuthorizationToken(pasToken)

--- a/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
+++ b/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
@@ -526,13 +526,10 @@ public class MainActivity extends BrightcovePlayer {
                 .setListener(new DatePickerFragment.Listener() {
                     @Override
                     public void onDateSelected(@NonNull Date expiryDate) {
-                        // Extend the playDuration value to the video duration plus an additional small amount to account for:
-                        // - Loading the video into the player (which starts the playDuration clock)
-                        // - Starting playback in a manual-start player
-                        long playDuration = video.getDurationLong() + PLAYDURATION_EXTENSION;
-                        if (playDuration == 0) {
-                            playDuration = DEFAULT_RENTAL_PLAY_DURATION;
-                        }
+                        // Use the default rental play duration for offline playback license.
+                        // This determines how long the content can be consumed after download,
+                        // not the actual video duration.
+                        long playDuration = DEFAULT_RENTAL_PLAY_DURATION;
 
                         HttpRequestConfig.Builder httpRequestConfigBuilder = new HttpRequestConfig.Builder();
                         httpRequestConfigBuilder.setBrightcoveAuthorizationToken(pasToken);


### PR DESCRIPTION
The current OfflinePlayback samples were unintuitively setting the rental time for videos to `video_length + 10s`. I changed it to use the default of 48h, which is closer to a real-case scenario. 