### PR TITLE
fix: correctly set DRM rent duration for offline playback

### DIFF
--- a/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt
+++ b/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt
@@ -460,13 +460,9 @@ class MainActivity : BrightcovePlayer() {
         DatePickerFragment().setTitle("Select Rental Expiry Date").setListener(
             object : DatePickerFragment.Listener {
                 override fun onDateSelected(expiryDate: Date) {
-                    // Extend the playDuration value to the video duration plus an additional small amount to account for:
-                    // - Loading the video into the player (which starts the playDuration clock)
-                    // - Starting playback in a manual-start player
-                    var playDuration: Long = video.durationLong + PLAYDURATION_EXTENSION
-                    if (playDuration == 0L) {
-                        playDuration = DEFAULT_RENTAL_PLAY_DURATION
-                    }
+                    // Set the playDuration so that it expires at the same time as the expiryDate.
+                    // This is because, for offline playback, Widevine cannot verify first playback time.
+                    val playDuration: Long = expiryDate.time - System.currentTimeMillis()
 
                     val httpRequestConfigBuilder = HttpRequestConfig.Builder()
                     httpRequestConfigBuilder.setBrightcoveAuthorizationToken(pasToken)

--- a/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
+++ b/brightcove-exoplayer/OfflinePlaybackSampleApp/src/main/java/com/brightcove/player/samples/offlineplayback/MainActivity.java
@@ -526,13 +526,9 @@ public class MainActivity extends BrightcovePlayer {
                 .setListener(new DatePickerFragment.Listener() {
                     @Override
                     public void onDateSelected(@NonNull Date expiryDate) {
-                        // Extend the playDuration value to the video duration plus an additional small amount to account for:
-                        // - Loading the video into the player (which starts the playDuration clock)
-                        // - Starting playback in a manual-start player
-                        long playDuration = video.getDurationLong() + PLAYDURATION_EXTENSION;
-                        if (playDuration == 0) {
-                            playDuration = DEFAULT_RENTAL_PLAY_DURATION;
-                        }
+                        // Set the playDuration so that it expires at the same time as the expiryDate.
+                        // This is because, for offline playback, Widevine cannot verify first playback time.
+                        long playDuration = expiryDate.getTime() - System.currentTimeMillis();
 
                         HttpRequestConfig.Builder httpRequestConfigBuilder = new HttpRequestConfig.Builder();
                         httpRequestConfigBuilder.setBrightcoveAuthorizationToken(pasToken);


### PR DESCRIPTION
# DRM and offline playback
When requesting a DRM license to Widevine, there are 2 parameters that can be passed:

- `rental_duration`: the total availability of the rental. Regardless of playback, after this has expired, the content won’t be available anymore. In the sample app, this is [the expiryDate variable](https://github.com/BrightcoveOS/android-player-samples/blob/master/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt#L476) that comes from the date selection picker.
- `playback_duration_seconds`: the number of seconds allowed for playback, starting to count from the beginning of the first playback. In the sample app, this is [the playDuration variable](https://github.com/BrightcoveOS/android-player-samples/blob/master/brightcove-exoplayer-kotlin/OfflinePlaybackSampleApp/src/main/java/com/brightcove/offline/playback/MainActivity.kt#L477) that is calculated as `video.durationLong + PLAYDURATION_EXTENSION` (video duration + 10s)

In theory, you could use both to offer the following feature: the user “rents” the video for N days (let’s say, 30), but once they start watching the video during those 30 days, they must finish watching it within 2 hours. To achieve this, in theory, you set `rental_duration` to 30 days, and `playback_duration_seconds` to 2 hours. In our case, we were setting `playback_duration_seconds` to the duration of the video (plus 10s for loading/buffering). The concept was "the user can only watch the video once".

The problem comes with offline playback: if the player is offline, *Widevine can’t track the actual “first playback”.* Consequently, *Widevine starts counting the time for `playback_duration_seconds` from the license acquisition*. This results in a bug that was reproducible in the sample app: the video becomes unavailable after videoDuration + 10s.

I change the logic to do the only thing we can: set `playDuration` to `expiryDate - now`. This means that `rental_duration` and `playback_duration_seconds` will have the same value, so the only "expiration" is the actual duration of the rental.

As far as I can tell, there is no "DRM-native" way of implementing the restriction on playback time. If the feature is desired, it must be implemented independently from the DRM system (that is: the app should observe playback events, count the seconds, and as soon as the user reached a certain number of seconds, it just makes the download unavailable).