### PR TITLE
Add seamless local development support via anpVersion=LOCAL

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -75,4 +75,52 @@ boolean pulseDependenciesAreSatisfied() {
     return dep.exists()
 }
 
+// Local SDK development support
+// Set anpVersion to:
+//   - Normal version: "10.2.2" (uses published artifacts)  
+//   - Local with default path: "LOCAL" (uses ../videocloud_android-native-player)
+//   - Local with custom path: "LOCAL:/path/to/sdk" (uses specified path)
+
+def localSdkPath = null
+def useLocalSdk = false
+
+if (anpVersion.startsWith('LOCAL')) {
+    useLocalSdk = true
+    if (anpVersion.contains(':')) {
+        // LOCAL:/path/to/sdk format
+        localSdkPath = anpVersion.substring(anpVersion.indexOf(':') + 1)
+    } else {
+        // Just "LOCAL" - use default path
+        localSdkPath = '../videocloud_android-native-player'
+    }
+}
+
+if (useLocalSdk) {
+    if (file(localSdkPath).exists()) {
+        println "Found local SDK at ${localSdkPath} - enabling composite build for seamless development"
+        
+        includeBuild(localSdkPath) {
+            dependencySubstitution {
+                substitute module('com.brightcove.player:android-sdk') using project(':sdk')
+                substitute module('com.brightcove.player:exoplayer2') using project(':players:exoplayer2')
+                substitute module('com.brightcove.player:android-ima-plugin') using project(':plugins:ima')
+                substitute module('com.brightcove.player:android-dai-plugin') using project(':plugins:ima-dai')
+                substitute module('com.brightcove.player:android-ssai-plugin') using project(':plugins:ssai')
+                substitute module('com.brightcove.player:android-cast-plugin') using project(':plugins:cast')
+                substitute module('com.brightcove.player:android-freewheel-plugin') using project(':plugins:freewheel')
+                substitute module('com.brightcove.player:android-pulse-plugin') using project(':plugins:pulse')
+                substitute module('com.brightcove.player:android-omniture-plugin') using project(':plugins:omniture')
+                substitute module('com.brightcove.player:android-appcompat-plugin') using project(':plugins:appcompat')
+                substitute module('com.brightcove.player:android-thumbnail-plugin') using project(':plugins:thumbnail')
+                substitute module('com.brightcove.player:offline-playback') using project(':plugins:offline-playback')
+                substitute module('com.brightcove.player:android-playback-notification-plugin') using project(':plugins:playback-notification')
+            }
+        }
+    } else {
+        throw new GradleException("Local SDK not found at ${localSdkPath}. Please check the path or use a published version instead.")
+    }
+} else {
+    println "Using published Maven artifacts version: ${anpVersion}"
+}
+
 


### PR DESCRIPTION
## Summary
- Add composite build configuration for local SDK development
- Support `anpVersion=LOCAL` for default path (`../videocloud_android-native-player`)
- Support `anpVersion=LOCAL:/path` for custom SDK paths  
- Automatic dependency substitution for all SDK modules and plugins
- Build fails gracefully if LOCAL path doesn't exist
- Eliminates need for `publishToMavenLocal` + sync workflow

## New anpVersion Options
- `anpVersion=10.2.2` → Uses published Maven artifacts (default behavior)
- `anpVersion=LOCAL` → Uses local SDK at `../videocloud_android-native-player`
- `anpVersion=LOCAL:/custom/path` → Uses local SDK at custom path

## Benefits  
- ✅ **No more publishToMavenLocal** - eliminates manual publish + sync steps
- ✅ **Live code changes** - immediate feedback without republishing
- ✅ **Fail-fast validation** - clear error if LOCAL path doesn't exist
- ✅ **Flexible configuration** - support for custom SDK paths
- ✅ **Seamless experience** - much faster development workflow

## Test plan
- [x] Verify `LOCAL` works with default path
- [x] Verify `LOCAL:/path` works with custom paths  
- [x] Verify normal version numbers still work
- [x] Verify build fails gracefully with invalid LOCAL paths
- [ ] Team review and testing

🤖 Generated with [Claude Code](https://claude.ai/code)