### PR TITLE
Clean up the sample app source (idiomatic, coherent, correct)

### DIFF
--- a/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/AndroidManifest.xml
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
-            android:name="com.brightcove.player.samples.basiccastbrightcovereceiver.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/MainActivity.java
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/MainActivity.java
@@ -29,6 +29,11 @@ import com.google.android.gms.cast.framework.Session;
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.INTENT_EXTRA_AD_CONFIG_ID;
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.INTENT_EXTRA_VIDEO_ID;
 
+/**
+ * Launcher screen for the Cast sample: loads a Video Cloud playlist, lists it in a
+ * RecyclerView, and hands the selected video to {@link VideoPlayerActivity} for local
+ * or Cast playback, optionally with server-side ad insertion.
+ */
 public class MainActivity extends AppCompatActivity implements VideoListAdapter.ItemClickListener {
 
     CheckBox chkBoxPlayVideoWithSsai;
@@ -46,8 +51,8 @@ public class MainActivity extends AppCompatActivity implements VideoListAdapter.
         videoListView.setAdapter(videoListAdapter);
         EventEmitter eventEmitter = new EventEmitterImpl();
 
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.accountId))
-                .setPolicy(getString(R.string.policyKey))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         catalog.findPlaylistByReferenceID(getString(R.string.playlistReferenceId), new PlaylistListener() {
@@ -64,7 +69,7 @@ public class MainActivity extends AppCompatActivity implements VideoListAdapter.
 
         chkBoxPlayVideoWithSsai.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
-                adConfigId = "ba5e4879-77f0-424b-8c98-706ae5ad7eec";
+                adConfigId = getString(R.string.sdk_demo_ad_config_id);
             } else {
                 adConfigId = "";
             }
@@ -102,7 +107,7 @@ public class MainActivity extends AppCompatActivity implements VideoListAdapter.
         @Override
         public void onSessionStarted(Session castSession, String s) {
             super.onSessionStarted(castSession, s);
-            String src = "https://dev.acquia.com/sites/default/files/blog/brightcove-logo-horizontal-grey-new.png";
+            String src = getString(R.string.sdk_demo_splash_screen_url);
             BrightcoveChannelUtil.castSplashScreen((CastSession) castSession, new SplashScreen(src));
         }
     };

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/VideoListAdapter.java
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/VideoListAdapter.java
@@ -14,10 +14,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.brightcove.player.model.Video;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.PROPERTY_SHORT_DESCRIPTION;
@@ -26,18 +24,16 @@ import coil3.SingletonImageLoader;
 import coil3.request.ImageRequest;
 import coil3.target.ImageViewTarget;
 
+/**
+ * RecyclerView adapter that renders each video's thumbnail, title, description, and
+ * duration and reports item clicks.
+ */
 public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.ViewHolder> {
 
     /**
      * The current list of videos.
      */
     private List<Video> videoList;
-
-    /**
-     * A map of video identifiers and position of video in the list.
-     */
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-    private Map<String, Integer> indexMap = new HashMap<>();
 
     private final ItemClickListener clickListener;
     public interface ItemClickListener {
@@ -130,20 +126,6 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
      */
     void setVideoList(@Nullable List<Video> videoList) {
         this.videoList = videoList;
-        buildIndexMap();
-    }
-
-    /**
-     * Build the index map.
-     */
-    private void buildIndexMap() {
-        indexMap.clear();
-        if (videoList != null) {
-            int index = 0;
-            for (Video video : videoList) {
-                indexMap.put(video.getId(), index++);
-            }
-        }
         notifyDataSetChanged();
     }
 

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/VideoPlayerActivity.java
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/java/VideoPlayerActivity.java
@@ -3,6 +3,7 @@ package com.brightcove.player.samples.basiccastbrightcovereceiver.java;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Menu;
 import android.widget.TextView;
 
@@ -17,6 +18,7 @@ import com.brightcove.cast.model.BrightcoveCastCustomData;
 import com.brightcove.cast.model.CustomData;
 import com.brightcove.player.appcompat.BrightcovePlayerActivity;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventType;
@@ -25,12 +27,19 @@ import com.brightcove.player.network.HttpRequestConfig;
 import com.brightcove.player.view.BrightcoveVideoView;
 import com.brightcove.ssai.SSAIComponent;
 
+import java.util.List;
+
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.INTENT_EXTRA_AD_CONFIG_ID;
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.INTENT_EXTRA_VIDEO_ID;
 import static com.brightcove.player.samples.basiccastbrightcovereceiver.java.Constants.PROPERTY_LONG_DESCRIPTION;
 
+/**
+ * Plays the selected video locally or on a connected Cast device via {@link GoogleCastComponent},
+ * optionally inserting server-side ads when an ad-config id is supplied.
+ */
 public class VideoPlayerActivity extends BrightcovePlayerActivity {
 
+    private static final String TAG = VideoPlayerActivity.class.getSimpleName();
     private static final String PROPERTY_APPLICATION_ID = "com.brightcove.player.samples.basiccastbrightcovereceiver.java";
 
     @Override
@@ -49,8 +58,8 @@ public class VideoPlayerActivity extends BrightcovePlayerActivity {
         String videoId = getIntent().getStringExtra(INTENT_EXTRA_VIDEO_ID);
         String adConfigId = getIntent().getStringExtra(INTENT_EXTRA_AD_CONFIG_ID);
 
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.accountId))
-                .setPolicy(getString(R.string.policyKey))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         HttpRequestConfig.Builder httpRequestConfigBuilder = new HttpRequestConfig.Builder();
@@ -83,6 +92,11 @@ public class VideoPlayerActivity extends BrightcovePlayerActivity {
                     baseVideoView.add(video);
                 }
             }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
+            }
         });
 
         eventEmitter.on(GoogleCastEventType.CAST_SESSION_STARTED, event -> {
@@ -94,9 +108,9 @@ public class VideoPlayerActivity extends BrightcovePlayerActivity {
         });
 
         CustomData customData = new BrightcoveCastCustomData.Builder(this)
-                .setAccountId(getString(R.string.accountId))
+                .setAccountId(getString(R.string.sdk_demo_account))
                 // Set your account’s policy key
-                .setPolicyKey(getString(R.string.policyKey))
+                .setPolicyKey(getString(R.string.sdk_demo_policy))
                 // Optional: Set your Edge Playback Authorization (EPA) JWT token here
                 // Note that if you set the EPA token, you will not need to set the Policy Key
                 .setBrightcoveAuthorizationToken(null)

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/res/values/strings.xml
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-java/src/main/res/values/strings.xml
@@ -7,13 +7,19 @@
     <string name="media_route_menu_title">Play on&#8230;</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="accountId">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policyKey">BCpkADawqM1Ui0_Pf1vky51aMs6LC42kmrxlpeAVxFf1bXtDKneGKJiJQoQklpT4D3aKBBoG7ryONbKKQsxErIVqaXz35LbfeL_UAYIjKqxw8q3jgh8P9j47pMWvrQJON-4P1hC2LfFmuGA_</string>
+    <string name="sdk_demo_policy">BCpkADawqM1Ui0_Pf1vky51aMs6LC42kmrxlpeAVxFf1bXtDKneGKJiJQoQklpT4D3aKBBoG7ryONbKKQsxErIVqaXz35LbfeL_UAYIjKqxw8q3jgh8P9j47pMWvrQJON-4P1hC2LfFmuGA_</string>
 
     <!-- A sample Brightcove Playlist Reference ID -->
     <string name="playlistReferenceId">android_sdk_demo_playlist</string>
+
+    <!-- A sample VideoCloud SSAI ad-config id -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
+
+    <!-- Splash image cast to the receiver when a Cast session starts -->
+    <string name="sdk_demo_splash_screen_url">https://dev.acquia.com/sites/default/files/blog/brightcove-logo-horizontal-grey-new.png</string>
 
     <string name="video_title">Video Title</string>
     <string name="video_thumbnail">Video Thumbnail</string>

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/README.md
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Adds Google Cast support to a Brightcove player and casts to the Brightcove Cast
 
 | File | Responsibility |
 |---|---|
-| `BasicCastBrightcoveReceiverActivity.kt` | Launcher activity; loads the demo playlist through the Catalog, shows it in a `RecyclerView`, adds the Cast media-route button, casts a splash screen when a session starts, and launches the player for the selected video. |
+| `MainActivity.kt` | Launcher activity; loads the demo playlist through the Catalog, shows it in a `RecyclerView`, adds the Cast media-route button, casts a splash screen when a session starts, and launches the player for the selected video. |
 | `VideoPlayerActivity.kt` | Plays the chosen video locally or on the Cast device; builds the Brightcove Cast custom data, wires up `GoogleCastComponent`, and optionally processes SSAI ads. |
 | `VideoListAdapter.kt` | `ListAdapter` (with `DiffUtil`) that renders each video's thumbnail, title, description, and duration and reports item clicks. |
 | `Constants.kt` | Intent-extra keys and video-property keys shared across the activities. |

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
-            android:name=".BasicCastBrightcoveReceiverActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.AppCastReceiver"
@@ -49,7 +49,7 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.BrightcoveCast"
             android:screenOrientation="portrait"
-            android:parentActivityName=".BasicCastBrightcoveReceiverActivity"
+            android:parentActivityName=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/MainActivity.kt
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/MainActivity.kt
@@ -26,7 +26,12 @@ import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.Session
 
-class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
+/**
+ * Launcher screen for the Cast sample: loads a Video Cloud playlist, lists it in a
+ * RecyclerView, and hands the selected video to [VideoPlayerActivity] for local or
+ * Cast playback, optionally with server-side ad insertion.
+ */
+class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityBasicCastBrightcoveReceiverBinding
     private lateinit var adapter: VideoListAdapter
@@ -43,7 +48,6 @@ class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
 
         videoListView.layoutManager =  LinearLayoutManager(this)
 
-        //manage the onClick Event
         adapter = VideoListAdapter{view, video ->
             itemClicked(view, video)
         }
@@ -51,8 +55,8 @@ class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
 
         val eventEmitter: EventEmitter = EventEmitterImpl()
 
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.accountId))
-            .setPolicy(getString(R.string.policyKey))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         catalog.findPlaylistByReferenceID(
@@ -68,7 +72,7 @@ class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
 
 
         checkPlayVideoWithSsai.setOnCheckedChangeListener{_, isChecked ->
-            adConfigId = if(isChecked) "ba5e4879-77f0-424b-8c98-706ae5ad7eec" else ""
+            adConfigId = if(isChecked) getString(R.string.sdk_demo_ad_config_id) else ""
         }
     }
 
@@ -87,7 +91,7 @@ class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         super.onCreateOptionsMenu(menu)
-        GoogleCastComponent.setUpMediaRouteButton(this, menu!!)
+        menu?.let { GoogleCastComponent.setUpMediaRouteButton(this, it) }
         return true
     }
 
@@ -101,7 +105,7 @@ class BasicCastBrightcoveReceiverActivity : AppCompatActivity() {
         object : DefaultSessionManagerListener() {
             override fun onSessionStarted(castSession: Session, s: String) {
                 super.onSessionStarted(castSession, s)
-                val src = "https://dev.acquia.com/sites/default/files/blog/brightcove-logo-horizontal-grey-new.png"
+                val src = getString(R.string.sdk_demo_splash_screen_url)
                 BrightcoveChannelUtil.castSplashScreen((castSession as CastSession),
                     SplashScreen(src)
                 )

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoListAdapter.kt
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoListAdapter.kt
@@ -44,7 +44,7 @@ class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Vid
                 val descriptionObj: String? = video.properties[Constants.PROPERTY_SHORT_DESCRIPTION]?.toString()
 
                 if(!descriptionObj.isNullOrBlank())
-                    videoDurationText.text = descriptionObj
+                    videoDescriptionText.text = descriptionObj
 
                 if (video.durationLong > 0) {
                     videoDurationText.text = millisecondsToString(video.durationLong)

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoListAdapter.kt
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoListAdapter.kt
@@ -9,12 +9,16 @@ import androidx.recyclerview.widget.RecyclerView
 import coil3.load
 import com.brightcove.player.samples.basiccastbrightcovereceiver.kotlin.databinding.ItemViewBinding
 import com.brightcove.player.model.Video
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 
 typealias OnVideoClick = (View, Video) -> Unit
 
+/**
+ * ListAdapter that renders each video's thumbnail, title, description, and duration
+ * and reports item clicks.
+ */
 class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Video, VideoListAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -23,7 +27,6 @@ class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Vid
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        //Get Video information
         holder.bind(getItem(position))
     }
 
@@ -36,7 +39,6 @@ class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Vid
 
             binding.apply {
 
-                //Set Video info
                 videoTitleText.text = video.name
 
                 val descriptionObj: String? = video.properties[Constants.PROPERTY_SHORT_DESCRIPTION]?.toString()
@@ -59,7 +61,6 @@ class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Vid
                     videoThumbnailImage.load(imageUri.toASCIIString())
                 }
 
-                //Adding onCLick Listener to the view
                 videoThumbnailImage.setOnClickListener{
                     onVideoClick(this.root,video)
                 }
@@ -101,7 +102,7 @@ class VideoListAdapter(private val onVideoClick: OnVideoClick) : ListAdapter<Vid
                 oldItem.id == newItem.id
 
             override fun areContentsTheSame(oldItem: Video, newItem: Video): Boolean =
-                oldItem.equals(newItem)
+                oldItem == newItem
         }
     }
 }

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoPlayerActivity.kt
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basiccastbrightcovereceiver/kotlin/VideoPlayerActivity.kt
@@ -2,6 +2,7 @@ package com.brightcove.player.samples.basiccastbrightcovereceiver.kotlin
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import androidx.core.view.ViewCompat
 import com.brightcove.cast.GoogleCastComponent
@@ -11,6 +12,7 @@ import com.brightcove.cast.model.CustomData
 import com.brightcove.player.samples.basiccastbrightcovereceiver.kotlin.databinding.ActivityPlayerBinding
 import com.brightcove.player.appcompat.BrightcovePlayerActivity
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.Event
 import com.brightcove.player.event.EventType
@@ -19,6 +21,10 @@ import com.brightcove.player.network.HttpRequestConfig
 import com.brightcove.ssai.SSAIComponent
 
 
+/**
+ * Plays the selected video locally or on a connected Cast device via [GoogleCastComponent],
+ * optionally inserting server-side ads when an ad-config id is supplied.
+ */
 class VideoPlayerActivity: BrightcovePlayerActivity() {
 
     private val PROPERTY_APPLICATION_ID = "com.brightcove.player.samples.basiccastbrightcovereceiver.kotlin"
@@ -40,8 +46,8 @@ class VideoPlayerActivity: BrightcovePlayerActivity() {
         val videoId = intent.getStringExtra(Constants.INTENT_EXTRA_VIDEO_ID) ?: ""
         val adConfigId = intent.getStringExtra(Constants.INTENT_EXTRA_AD_CONFIG_ID) ?: ""
 
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.accountId))
-            .setPolicy(getString(R.string.policyKey))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         val httpRequestConfigBuilder = HttpRequestConfig.Builder()
@@ -67,6 +73,10 @@ class VideoPlayerActivity: BrightcovePlayerActivity() {
                         baseVideoView.add(video)
                     }
                 }
+
+                override fun onError(errors: List<CatalogError>) {
+                    Log.e(TAG, errors.toString())
+                }
             })
 
         eventEmitter.on(GoogleCastEventType.CAST_SESSION_STARTED) { event: Event? ->
@@ -77,9 +87,9 @@ class VideoPlayerActivity: BrightcovePlayerActivity() {
         }
 
         val customData: CustomData = BrightcoveCastCustomData.Builder(this)
-            .setAccountId(getString(R.string.accountId))
+            .setAccountId(getString(R.string.sdk_demo_account))
             // Set your account’s policy key
-            .setPolicyKey(getString(R.string.policyKey))
+            .setPolicyKey(getString(R.string.sdk_demo_policy))
             // Optional: Set your Edge Playback Authorization (EPA) JWT token here
             // Note that if you set the EPA token, you will not need to set the Policy Key
             .setBrightcoveAuthorizationToken(null)
@@ -116,5 +126,9 @@ class VideoPlayerActivity: BrightcovePlayerActivity() {
             eventEmitter.emit(EventType.ENTER_FULL_SCREEN)
             actionBar?.hide()
         }
+    }
+
+    companion object {
+        private const val TAG = "VideoPlayerActivity"
     }
 }

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/res/layout/activity_basic_cast_brightcove_receiver.xml
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/res/layout/activity_basic_cast_brightcove_receiver.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".BasicCastBrightcoveReceiverActivity">
+    tools:context=".MainActivity">
 
     <CheckBox
         android:id="@+id/chkBoxPlayVideoWithSsai"

--- a/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Cast/BasicCastBrightcoveReceiverSampleApp-kotlin/src/main/res/values/strings.xml
@@ -7,13 +7,19 @@
     <string name="media_route_menu_title">Play on&#8230;</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="accountId">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policyKey">BCpkADawqM1Ui0_Pf1vky51aMs6LC42kmrxlpeAVxFf1bXtDKneGKJiJQoQklpT4D3aKBBoG7ryONbKKQsxErIVqaXz35LbfeL_UAYIjKqxw8q3jgh8P9j47pMWvrQJON-4P1hC2LfFmuGA_</string>
+    <string name="sdk_demo_policy">BCpkADawqM1Ui0_Pf1vky51aMs6LC42kmrxlpeAVxFf1bXtDKneGKJiJQoQklpT4D3aKBBoG7ryONbKKQsxErIVqaXz35LbfeL_UAYIjKqxw8q3jgh8P9j47pMWvrQJON-4P1hC2LfFmuGA_</string>
 
     <!-- A sample Brightcove Playlist Reference ID -->
     <string name="playlistReferenceId">android_sdk_demo_playlist</string>
+
+    <!-- A sample VideoCloud SSAI ad-config id -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
+
+    <!-- Splash image cast to the receiver when a Cast session starts -->
+    <string name="sdk_demo_splash_screen_url">https://dev.acquia.com/sites/default/files/blog/brightcove-logo-horizontal-grey-new.png</string>
 
     <string name="video_title">Video Title</string>
     <string name="video_thumbnail">Video Thumbnail</string>

--- a/DAI/BasicDAISampleApp-java/src/main/java/com/brightcove/player/samples/basicdai/java/MainActivity.java
+++ b/DAI/BasicDAISampleApp-java/src/main/java/com/brightcove/player/samples/basicdai/java/MainActivity.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.brightcove.dai.GoogleDAIComponent;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
@@ -13,9 +14,15 @@ import com.brightcove.player.view.BrightcovePlayer;
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory;
 import com.google.ads.interactivemedia.v3.api.ImaSdkSettings;
 
+import java.util.List;
+
+/**
+ * Plays a stream with Google Dynamic Ad Insertion (DAI), where ads are
+ * stitched into the stream server-side.
+ */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private static final String LIVE_BIG_BUCK_BUNNY_ASSET_KEY = "c-rArva4ShKVIAkNfy6HUQ";
     private static final String VOD_TEARS_OF_STEEL_CMS_ID = "2548831";
@@ -28,15 +35,15 @@ public class MainActivity extends BrightcovePlayer {
     private Catalog catalog;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         setContentView(R.layout.activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         eventEmitter = brightcoveVideoView.getEventEmitter();
         setupDAI();
-        catalog = new Catalog.Builder(eventEmitter, getString(R.string.account))
-                .setPolicy(getString(R.string.policy))
+        catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
         requestVideo();
     }
@@ -49,9 +56,11 @@ public class MainActivity extends BrightcovePlayer {
     }
 
     private void requestVideo() {
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             @Override
             public void onVideo(Video video) {
+                // Provide a fallback video to play if the DAI stream cannot be retrieved,
+                // then register a callback that receives the ad-stitched stream once it is ready.
                 googleDAIComponent.setFallbackVideo(video);
                 googleDAIComponent.addCallback(new GoogleDAIComponent.Listener() {
                     @Override
@@ -67,12 +76,15 @@ public class MainActivity extends BrightcovePlayer {
                     }
                 });
 
-                // Uncomment the next line if you want to request a live stream
+                // This sample requests a VOD stream. To request a live stream instead,
+                // uncomment the line below and comment out the requestVOD call.
                 //googleDAIComponent.requestLiveStream(LIVE_BIG_BUCK_BUNNY_ASSET_KEY, null);
-
-                // Uncomment the next line if you want to request a VOD
                 googleDAIComponent.requestVOD(VOD_TEARS_OF_STEEL_CMS_ID, VOD_TEARS_OF_STEEL_VIDEO_ID, null);
+            }
 
+            @Override
+            public void onError(List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/DAI/BasicDAISampleApp-java/src/main/res/values/strings.xml
+++ b/DAI/BasicDAISampleApp-java/src/main/res/values/strings.xml
@@ -2,11 +2,11 @@
     <string name="app_name">Basic DAI Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 </resources>

--- a/DAI/BasicDAISampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicdai/kotlin/MainActivity.kt
+++ b/DAI/BasicDAISampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicdai/kotlin/MainActivity.kt
@@ -4,26 +4,30 @@ import android.os.Bundle
 import android.util.Log
 import com.brightcove.dai.GoogleDAIComponent
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayer
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
 
+/**
+ * Plays a stream with Google Dynamic Ad Insertion (DAI), where ads are
+ * stitched into the stream server-side.
+ */
 class MainActivity : BrightcovePlayer() {
-    private val TAG = this.javaClass.simpleName
     private lateinit var eventEmitter: EventEmitter
     private lateinit var catalog: Catalog
     private lateinit var googleDAIComponent: GoogleDAIComponent
 
-    public override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         setContentView(R.layout.activity_main)
         brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
         eventEmitter = brightcoveVideoView.eventEmitter
         setupDAI()
-        catalog = Catalog.Builder(eventEmitter, getString(R.string.account))
-            .setPolicy(getString(R.string.policy))
+        catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
         requestVideo()
     }
@@ -36,8 +40,10 @@ class MainActivity : BrightcovePlayer() {
     }
 
     private fun requestVideo() {
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
+                // Provide a fallback video to play if the DAI stream cannot be retrieved,
+                // then register a callback that receives the ad-stitched stream once it is ready.
                 googleDAIComponent.setFallbackVideo(video)
                 googleDAIComponent.addCallback(object : GoogleDAIComponent.Listener {
                     override fun onStreamReady(video: Video) {
@@ -51,16 +57,20 @@ class MainActivity : BrightcovePlayer() {
                     }
                 })
 
-                // Uncomment the next line if you want to request a live stream
-                //googleDAIComponent.requestLiveStream(LIVE_BIG_BUCK_BUNNY_ASSET_KEY, null);
-
-                // Uncomment the next line if you want to request a VOD
+                // This sample requests a VOD stream. To request a live stream instead,
+                // uncomment the line below and comment out the requestVOD call.
+                //googleDAIComponent.requestLiveStream(LIVE_BIG_BUCK_BUNNY_ASSET_KEY, null)
                 googleDAIComponent.requestVOD(VOD_TEARS_OF_STEEL_CMS_ID, VOD_TEARS_OF_STEEL_VIDEO_ID, null)
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
     }
 
     companion object {
+        private const val TAG = "MainActivity"
         private const val LIVE_BIG_BUCK_BUNNY_ASSET_KEY = "c-rArva4ShKVIAkNfy6HUQ"
         private const val VOD_TEARS_OF_STEEL_CMS_ID = "2548831"
         private const val VOD_TEARS_OF_STEEL_VIDEO_ID = "tears-of-steel"

--- a/DAI/BasicDAISampleApp-kotlin/src/main/res/values/strings.xml
+++ b/DAI/BasicDAISampleApp-kotlin/src/main/res/values/strings.xml
@@ -2,11 +2,11 @@
     <string name="app_name">Basic DAI Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 </resources>

--- a/DRM/WidevineModularSampleApp-java/src/main/AndroidManifest.xml
+++ b/DRM/WidevineModularSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.widevinemodular.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/DRM/WidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/widevinemodular/java/MainActivity.java
+++ b/DRM/WidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/widevinemodular/java/MainActivity.java
@@ -1,12 +1,12 @@
 package com.brightcove.player.samples.widevinemodular.java;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.brightcove.player.edge.Catalog;
 import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
 import java.util.List;
@@ -17,24 +17,23 @@ import java.util.List;
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         Catalog catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             @Override
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
@@ -43,7 +42,7 @@ public class MainActivity extends BrightcovePlayer {
 
             @Override
             public void onError(List<CatalogError> errors) {
-                super.onError(errors);
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/DRM/WidevineModularSampleApp-java/src/main/res/values/strings.xml
+++ b/DRM/WidevineModularSampleApp-java/src/main/res/values/strings.xml
@@ -10,6 +10,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
 
 </resources>

--- a/DRM/WidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/widevinemodular/kotlin/MainActivity.kt
+++ b/DRM/WidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/widevinemodular/kotlin/MainActivity.kt
@@ -1,35 +1,45 @@
 package com.brightcove.player.samples.widevinemodular.kotlin
 
 import android.os.Bundle
-import android.view.View
+import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 
+/**
+ * This app illustrates how to use the ExoPlayer and Widevine Modular
+ * with the Brightcove Native Player SDK for Android.
+ */
 class MainActivity : BrightcovePlayer() {
     override fun onCreate(savedInstanceState: Bundle?) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main)
-        brightcoveVideoView =
-            findViewById<View>(R.id.brightcove_video_view) as BrightcoveExoPlayerVideoView
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         val catalog =
             Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/DRM/WidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/DRM/WidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
@@ -8,6 +8,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
 
 </resources>

--- a/FreeWheel/FreeWheelSampleApp-java/src/main/AndroidManifest.xml
+++ b/FreeWheel/FreeWheelSampleApp-java/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:usesCleartextTraffic="true">
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <activity
-            android:name="com.brightcove.player.samples.freewheel.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/FreeWheel/FreeWheelSampleApp-java/src/main/java/com/brightcove/player/samples/freewheel/java/MainActivity.java
+++ b/FreeWheel/FreeWheelSampleApp-java/src/main/java/com/brightcove/player/samples/freewheel/java/MainActivity.java
@@ -6,14 +6,10 @@ import android.view.ViewGroup;
 
 import com.brightcove.freewheel.controller.FreeWheelController;
 import com.brightcove.freewheel.event.FreeWheelEventType;
-import com.brightcove.player.edge.Catalog;
-import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
-import com.brightcove.player.event.EventListener;
 import com.brightcove.player.model.DeliveryType;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
 import java.util.List;
@@ -28,12 +24,10 @@ import tv.freewheel.ad.request.config.VideoAssetConfiguration;
 
 /**
  * This app illustrates how to use the FreeWheel plugin with the Brightcove Player for Android.
- *
- * @author Billy Hnath
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private EventEmitter eventEmitter;
 
@@ -43,7 +37,7 @@ public class MainActivity extends BrightcovePlayer {
         // before entering the superclass. This allows for some stock video player lifecycle
         // management.
         setContentView(R.layout.freewheel_activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         eventEmitter = brightcoveVideoView.getEventEmitter();
@@ -57,10 +51,9 @@ public class MainActivity extends BrightcovePlayer {
 
     private void setupFreeWheel() {
 
-        //change this to new FrameLayout based constructor.
         FreeWheelController freeWheelController = new FreeWheelController(this, brightcoveVideoView, eventEmitter);
         //configure your own IAdManager or supply connection information
-        freeWheelController.setAdURL("http://demo.v.fwmrm.net/");
+        freeWheelController.setAdURL(getString(R.string.sdk_demo_ad_server_url));
         freeWheelController.setAdNetworkId(90750);
         freeWheelController.setProfile("3pqa_android");
 
@@ -78,9 +71,7 @@ public class MainActivity extends BrightcovePlayer {
             ViewGroup adView = findViewById(R.id.ad_frame);
 
             // Clean out any previous display ads
-            for (int i = 0; i < adView.getChildCount(); i++) {
-                adView.removeViewAt(i);
-            }
+            adView.removeAllViews();
 
             if (slots != null) {
                 for (ISlot slot : slots) {

--- a/FreeWheel/FreeWheelSampleApp-java/src/main/res/values/strings.xml
+++ b/FreeWheel/FreeWheelSampleApp-java/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <!-- A sample Video URL-->
     <string name="sdk_demo_video_url">https://media.w3.org/2010/05/sintel/trailer.mp4</string>
 
+    <!-- FreeWheel demo ad server (cleartext http) -->
+    <string name="sdk_demo_ad_server_url">http://demo.v.fwmrm.net/</string>
+
 </resources>

--- a/FreeWheel/FreeWheelSampleApp-kotlin/src/main/java/com/brightcove/player/samples/freewheel/kotlin/MainActivity.kt
+++ b/FreeWheel/FreeWheelSampleApp-kotlin/src/main/java/com/brightcove/player/samples/freewheel/kotlin/MainActivity.kt
@@ -9,7 +9,6 @@ import com.brightcove.player.event.Event
 import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.model.DeliveryType
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 import tv.freewheel.ad.interfaces.IAdContext
 import tv.freewheel.ad.interfaces.IConstants
@@ -19,6 +18,9 @@ import tv.freewheel.ad.request.config.NonTemporalSlotConfiguration
 import tv.freewheel.ad.request.config.TemporalSlotConfiguration
 import tv.freewheel.ad.request.config.VideoAssetConfiguration
 
+/**
+ * This app illustrates how to use the FreeWheel plugin with the Brightcove Player for Android.
+ */
 class MainActivity : BrightcovePlayer() {
     private var eventEmitter: EventEmitter? = null
 
@@ -27,7 +29,7 @@ class MainActivity : BrightcovePlayer() {
         // before entering the superclass. This allows for some stock video player lifecycle
         // management.
         setContentView(R.layout.activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         eventEmitter = brightcoveVideoView.eventEmitter
@@ -40,11 +42,9 @@ class MainActivity : BrightcovePlayer() {
     }
 
     private fun setupFreeWheel() {
-        //change this to new FrameLayout based constructor.
-
         val freeWheelController = FreeWheelController(this, brightcoveVideoView, eventEmitter)
         //configure your own IAdManager or supply connection information
-        freeWheelController.setAdURL("http://demo.v.fwmrm.net/")
+        freeWheelController.setAdURL(getString(R.string.sdk_demo_ad_server_url))
         freeWheelController.setAdNetworkId(90750)
         freeWheelController.setProfile("3pqa_android")
 
@@ -53,7 +53,7 @@ class MainActivity : BrightcovePlayer() {
          * - 3pqa_section - uses FW server rules - always returns a preroll and a postroll.  It should return whatever midroll slots you request though.
          * - 3pqa_section_nocbp - returns the slots that you request.
          */
-        //freeWheelController.setSiteSectionId("3pqa_section");
+        //freeWheelController.setSiteSectionId("3pqa_section")
         freeWheelController.setSiteSectionId("3pqa_section_nocbp")
 
         eventEmitter?.on(FreeWheelEventType.SHOW_DISPLAY_ADS) { event: Event ->
@@ -61,9 +61,7 @@ class MainActivity : BrightcovePlayer() {
             val adView = findViewById<ViewGroup>(R.id.ad_frame)
 
             // Clean out any previous display ads
-            for (i in 0 until adView.childCount) {
-                adView.removeViewAt(i)
-            }
+            adView.removeAllViews()
             slots?.forEach { slot ->
                 adView.addView(slot.base)
                 slot.play()
@@ -126,5 +124,9 @@ class MainActivity : BrightcovePlayer() {
             adRequestConfiguration?.addSlotConfiguration(overlaySlot)
         }
         freeWheelController.enable()
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/FreeWheel/FreeWheelSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/FreeWheel/FreeWheelSampleApp-kotlin/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <!-- A sample Video URL-->
     <string name="sdk_demo_video_url">https://media.w3.org/2010/05/sintel/trailer.mp4</string>
 
+    <!-- FreeWheel demo ad server (cleartext http) -->
+    <string name="sdk_demo_ad_server_url">http://demo.v.fwmrm.net/</string>
+
 </resources>

--- a/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/AndroidManifest.xml
+++ b/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         android:usesCleartextTraffic="true">
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <activity
-            android:name="com.brightcove.player.samples.freewheelwidevinemodular.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/java/MainActivity.java
+++ b/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/java/MainActivity.java
@@ -7,11 +7,11 @@ import android.view.ViewGroup;
 import com.brightcove.freewheel.controller.FreeWheelController;
 import com.brightcove.freewheel.event.FreeWheelEventType;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
 import java.util.List;
@@ -27,13 +27,10 @@ import tv.freewheel.ad.request.config.VideoAssetConfiguration;
 /**
  * This app illustrates how to use the FreeWheel and Widevine plugins
  * together with the Brightcove Player for Android.
- *
- * @author Billy Hnath
- * @author Sergio Martinez
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private EventEmitter eventEmitter;
 
@@ -43,33 +40,35 @@ public class MainActivity extends BrightcovePlayer {
         // before entering the superclass. This allows for some stock video player lifecycle
         // management.
         setContentView(R.layout.freewheel_activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
         eventEmitter = brightcoveVideoView.getEventEmitter();
 
         setupFreeWheel();
 
-        Catalog catalog = new Catalog(
-                brightcoveVideoView.getEventEmitter(),
-                getString(R.string.sdk_demo_account),
-                getString(R.string.sdk_demo_policy));
+        Catalog catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
+                .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             @Override
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
             }
-        });
 
+            @Override
+            public void onError(List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
+            }
+        });
     }
 
     private void setupFreeWheel() {
 
-        //change this to new FrameLayout based constructor.
         FreeWheelController freeWheelController = new FreeWheelController(this, brightcoveVideoView, eventEmitter);
         //configure your own IAdManager or supply connection information
-        freeWheelController.setAdURL("http://demo.v.fwmrm.net/");
+        freeWheelController.setAdURL(getString(R.string.sdk_demo_ad_server_url));
         freeWheelController.setAdNetworkId(90750);
         freeWheelController.setProfile("3pqa_android");
 
@@ -87,9 +86,7 @@ public class MainActivity extends BrightcovePlayer {
             ViewGroup adView = findViewById(R.id.ad_frame);
 
             // Clean out any previous display ads
-            for (int i = 0; i < adView.getChildCount(); i++) {
-                adView.removeViewAt(i);
-            }
+            adView.removeAllViews();
 
             if (slots != null) {
                 for (ISlot slot : slots) {

--- a/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/res/values/strings.xml
+++ b/FreeWheel/FreeWheelWidevineModularSampleApp-java/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
+
+    <!-- FreeWheel ad server endpoint -->
+    <string name="sdk_demo_ad_server_url">http://demo.v.fwmrm.net/</string>
 
 </resources>

--- a/FreeWheel/FreeWheelWidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/kotlin/MainActivity.kt
+++ b/FreeWheel/FreeWheelWidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/freewheelwidevinemodular/kotlin/MainActivity.kt
@@ -6,11 +6,11 @@ import android.view.ViewGroup
 import com.brightcove.freewheel.controller.FreeWheelController
 import com.brightcove.freewheel.event.FreeWheelEventType
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.Event
 import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 import tv.freewheel.ad.interfaces.IAdContext
 import tv.freewheel.ad.interfaces.IConstants
@@ -20,41 +20,47 @@ import tv.freewheel.ad.request.config.NonTemporalSlotConfiguration
 import tv.freewheel.ad.request.config.TemporalSlotConfiguration
 import tv.freewheel.ad.request.config.VideoAssetConfiguration
 
+/**
+ * This app illustrates how to use the FreeWheel and Widevine plugins
+ * together with the Brightcove Player for Android.
+ */
 class MainActivity : BrightcovePlayer() {
     private var eventEmitter: EventEmitter? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // When extending the BrightcovePlayer, we must assign the BrightcoveExoPlayerVideoView
+        // When extending the BrightcovePlayer, we must assign the brightcoveVideoView
         // before entering the superclass. This allows for some stock video player lifecycle
         // management.
         setContentView(R.layout.activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         eventEmitter = brightcoveVideoView.eventEmitter
 
         setupFreeWheel()
 
-        val catalog = Catalog(
-            brightcoveVideoView.eventEmitter,
-            getString(R.string.sdk_demo_account),
-            getString(R.string.sdk_demo_policy)
-        )
+        val catalog =
+            Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
+                .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
-            override fun onVideo(video: Video?) {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
+            override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
     }
 
     private fun setupFreeWheel() {
-        //change this to new FrameLayout based constructor.
 
         val freeWheelController = FreeWheelController(this, brightcoveVideoView, eventEmitter)
         //configure your own IAdManager or supply connection information
-        freeWheelController.setAdURL("http://demo.v.fwmrm.net/")
+        freeWheelController.setAdURL(getString(R.string.sdk_demo_ad_server_url))
         freeWheelController.setAdNetworkId(90750)
         freeWheelController.setProfile("3pqa_android")
 
@@ -63,7 +69,7 @@ class MainActivity : BrightcovePlayer() {
          * - 3pqa_section - uses FW server rules - always returns a preroll and a postroll.  It should return whatever midroll slots you request though.
          * - 3pqa_section_nocbp - returns the slots that you request.
          */
-        //freeWheelController.setSiteSectionId("3pqa_section");
+        //freeWheelController.setSiteSectionId("3pqa_section")
         freeWheelController.setSiteSectionId("3pqa_section_nocbp")
 
         eventEmitter?.on(FreeWheelEventType.SHOW_DISPLAY_ADS) { event: Event ->
@@ -71,9 +77,7 @@ class MainActivity : BrightcovePlayer() {
             val adView = findViewById<ViewGroup>(R.id.ad_frame)
 
             // Clean out any previous display ads
-            for (i in 0 until adView.childCount) {
-                adView.removeViewAt(i)
-            }
+            adView.removeAllViews()
             slots?.forEach { slot ->
                 adView.addView(slot.base)
                 slot.play()
@@ -137,5 +141,9 @@ class MainActivity : BrightcovePlayer() {
             adRequestConfiguration?.addSlotConfiguration(overlaySlot)
         }
         freeWheelController.enable()
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/FreeWheel/FreeWheelWidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/FreeWheel/FreeWheelWidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
@@ -8,5 +8,8 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
+
+    <!-- FreeWheel ad server endpoint -->
+    <string name="sdk_demo_ad_server_url">http://demo.v.fwmrm.net/</string>
 </resources>

--- a/IMA/AdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/adrulesima/java/MainActivity.java
+++ b/IMA/AdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/adrulesima/java/MainActivity.java
@@ -17,7 +17,6 @@ import com.brightcove.player.mediacontroller.BrightcoveMediaController;
 import com.brightcove.player.mediacontroller.BrightcoveSeekBar;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BaseVideoView;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 import com.google.ads.interactivemedia.v3.api.AdsManager;
 import com.google.ads.interactivemedia.v3.api.AdsRequest;
@@ -32,20 +31,15 @@ import java.util.List;
  *
  * Note: Video cue points are not used with IMA Ad Rules. The AdCuePoints referenced
  * in the setupAdMarkers method below are Google IMA objects.
- *
- * @author Paul Matthew Reilly (original code)
- * @author Paul Michael Reilly (added explanatory comments)
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private EventEmitter eventEmitter;
 
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private GoogleIMAComponent googleIMAComponent;
-
-    private final String adRulesURL = "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,7 +47,7 @@ public class MainActivity extends BrightcovePlayer {
         // entering the superclass. This allows for some stock video player lifecycle
         // management.
         setContentView(R.layout.ima_activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
 
         // *** This method call is optional *** //
         setupAdMarkers(brightcoveVideoView);
@@ -64,11 +58,12 @@ public class MainActivity extends BrightcovePlayer {
         // Use a procedural abstraction to setup the Google IMA SDK via the plugin.
         setupGoogleIMA();
 
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.account))
-                .setPolicy(getString(R.string.policy))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
+            @Override
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
 
@@ -77,6 +72,7 @@ public class MainActivity extends BrightcovePlayer {
                 brightcoveVideoView.start();
             }
 
+            @Override
             public void onError(@NonNull List<CatalogError> errors) {
                 Log.e(TAG, errors.toString());
             }
@@ -90,7 +86,7 @@ public class MainActivity extends BrightcovePlayer {
         // Establish the Google IMA SDK factory instance.
         final ImaSdkFactory sdkFactory = ImaSdkFactory.getInstance();
 
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED, event -> Log.v(TAG, event.getType()));
 
         // Enable logging any failed attempts to play an ad.
@@ -106,7 +102,7 @@ public class MainActivity extends BrightcovePlayer {
             // Build an ads request object and point it to the ad
             // display container created above.
             AdsRequest adsRequest = sdkFactory.createAdsRequest();
-            adsRequest.setAdTagUrl(adRulesURL);
+            adsRequest.setAdTagUrl(getString(R.string.adRulesUrl));
 
             ArrayList<AdsRequest> adsRequests = new ArrayList<>(1);
             adsRequests.add(adsRequest);
@@ -124,7 +120,7 @@ public class MainActivity extends BrightcovePlayer {
     }
 
     /*
-      This methods show how to the the Google IMA AdsManager, get the cue points and add the markers
+      This method shows how to use the Google IMA AdsManager, get the cue points and add the markers
       to the Brightcove Seek Bar.
      */
     private void setupAdMarkers(BaseVideoView videoView) {

--- a/IMA/AdRulesIMASampleApp-java/src/main/res/values/strings.xml
+++ b/IMA/AdRulesIMASampleApp-java/src/main/res/values/strings.xml
@@ -4,12 +4,15 @@
     <string name="app_name">Ad Rules IMA Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
+
+    <!-- A sample Brightcove ad rules URL -->
+    <string name="adRulesUrl">https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&amp;iu=/124319096/external/single_ad_samples&amp;ciu_szs=300x250&amp;impl=s&amp;gdfp_req=1&amp;env=vp&amp;output=vast&amp;unviewed_position_start=1&amp;cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&amp;correlator=</string>
 
 </resources>

--- a/IMA/AdRulesIMASampleApp-kotlin/README.md
+++ b/IMA/AdRulesIMASampleApp-kotlin/README.md
@@ -6,6 +6,6 @@ Plays a Brightcove video with Google IMA ads scheduled server-side through IMA a
 
 | File | Responsibility |
 |---|---|
-| `AdRulesIMASampleApp.kt` | Loads a video from the `Catalog`, configures the Google IMA plugin with ad rules enabled, answers the ad request with a VMAP ad tag URL, and adds ad markers to the seek bar. |
+| `MainActivity.kt` | Loads a video from the `Catalog`, configures the Google IMA plugin with ad rules enabled, answers the ad request with a VMAP ad tag URL, and adds ad markers to the seek bar. |
 
 See the [IMA ads README](../) for shared setup and requirements.

--- a/IMA/AdRulesIMASampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/IMA/AdRulesIMASampleApp-kotlin/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:value="@integer/google_play_services_version" />
 
         <activity
-            android:name=".AdRulesIMASampleApp"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:exported="true">

--- a/IMA/AdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/adrulesima/kotlin/MainActivity.kt
+++ b/IMA/AdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/adrulesima/kotlin/MainActivity.kt
@@ -30,18 +30,11 @@ import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
  * in the setupAdMarkers method below are Google IMA objects.
  */
 
-class AdRulesIMASampleApp : BrightcovePlayer() {
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityAdRulesImaSampleAppBinding
     private lateinit var eventEmitter: EventEmitter
     private lateinit var googleIMAComponent: GoogleIMAComponent
-
-    val TAG = this.javaClass.simpleName
-
-
-    private val adRulesURL =
-        "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator="
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -66,11 +59,11 @@ class AdRulesIMASampleApp : BrightcovePlayer() {
         // Use a procedural abstraction to setup the Google IMA SDK via the plugin.
         setupGoogleIMA()
 
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.account))
-            .setPolicy(getString(R.string.policy))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
 
@@ -92,7 +85,7 @@ class AdRulesIMASampleApp : BrightcovePlayer() {
         // Establish the Google IMA SDK factory instance.
         val sdkFactory = ImaSdkFactory.getInstance()
 
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED) { event: Event ->
             Log.v(TAG, event.type)
         }
@@ -114,7 +107,7 @@ class AdRulesIMASampleApp : BrightcovePlayer() {
             // Build an ads request object and point it to the ad
             // display container created above.
             val adsRequest = sdkFactory.createAdsRequest()
-            adsRequest.adTagUrl = adRulesURL
+            adsRequest.adTagUrl = getString(R.string.adRulesUrl)
 
             val adsRequests = arrayListOf<AdsRequest>(adsRequest)
 
@@ -132,7 +125,7 @@ class AdRulesIMASampleApp : BrightcovePlayer() {
 
 
     /*
-      This methods show how to the the Google IMA AdsManager, get the cue points and add the markers
+      This method shows how to use the Google IMA AdsManager, get the cue points and add the markers
       to the Brightcove Seek Bar.
      */
     private fun setupAdMarkers(videoView: BaseVideoView) {
@@ -156,5 +149,9 @@ class AdRulesIMASampleApp : BrightcovePlayer() {
             }
         }
         videoView.setMediaController(mediaController)
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/IMA/AdRulesIMASampleApp-kotlin/src/main/res/layout/activity_ad_rules_ima_sample_app.xml
+++ b/IMA/AdRulesIMASampleApp-kotlin/src/main/res/layout/activity_ad_rules_ima_sample_app.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".AdRulesIMASampleApp">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/IMA/AdRulesIMASampleApp-kotlin/src/main/res/values/strings.xml
+++ b/IMA/AdRulesIMASampleApp-kotlin/src/main/res/values/strings.xml
@@ -4,12 +4,15 @@
     <string name="app_name">Ad Rules IMA Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
+
+    <!-- A sample Brightcove ad rules URL -->
+    <string name="adRulesUrl">https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&amp;iu=/124319096/external/single_ad_samples&amp;ciu_szs=300x250&amp;impl=s&amp;gdfp_req=1&amp;env=vp&amp;output=vast&amp;unviewed_position_start=1&amp;cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&amp;correlator=</string>
 
 </resources>

--- a/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/AndroidManifest.xml
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
         <activity
-            android:name="com.brightcove.player.samples.adrulesimawidevinemodular.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/adrulesimawidevinemodular/java/MainActivity.java
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/java/com/brightcove/player/samples/adrulesimawidevinemodular/java/MainActivity.java
@@ -27,13 +27,10 @@ import java.util.List;
  * <p>
  * Note: Video cue points are not used with IMA Ad Rules. The AdCuePoints referenced
  * in the setupAdMarkers method below are Google IMA objects.
- *
- * @author Paul Matthew Reilly (original code)
- * @author Paul Michael Reilly (added explanatory comments)
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private EventEmitter eventEmitter;
 
@@ -54,11 +51,11 @@ public class MainActivity extends BrightcovePlayer {
         setupGoogleIMA();
 
         // Create the catalog object which will start and play the video.
-        Catalog catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), getString(R.string.account))
-                .setPolicy(getString(R.string.policy))
+        Catalog catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             @Override
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
@@ -82,13 +79,13 @@ public class MainActivity extends BrightcovePlayer {
         // Establish the Google IMA SDK factory instance.
         final ImaSdkFactory sdkFactory = ImaSdkFactory.getInstance();
 
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED, event -> Log.v(TAG, event.getType()));
 
         // Enable logging any failed attempts to play an ad.
         eventEmitter.on(GoogleIMAEventType.DID_FAIL_TO_PLAY_AD, event -> Log.v(TAG, event.getType()));
 
-        // Enable Logging upon ad completion.
+        // Enable logging upon ad completion.
         eventEmitter.on(EventType.AD_COMPLETED, event -> Log.v(TAG, event.getType()));
 
         // Set up a listener for initializing AdsRequests. The Google
@@ -113,7 +110,5 @@ public class MainActivity extends BrightcovePlayer {
         googleIMAComponent = new GoogleIMAComponent.Builder(brightcoveVideoView, eventEmitter)
                 .setUseAdRules(true)
                 .build();
-
-        // Calling GoogleIMAComponent.initializeAdsRequests() is no longer necessary.
     }
 }

--- a/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/res/values/strings.xml
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-java/src/main/res/values/strings.xml
@@ -4,13 +4,13 @@
     <string name="app_name">Ad Rules IMA Widevine Modular Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
 
     <!-- A sample Brightcove ad rules URL -->
     <string name="adRulesUrl">http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&amp;iu=%2F15018773%2Feverything2&amp;ciu_szs=300x250%2C468x60%2C728x90&amp;impl=s&amp;gdfp_req=1&amp;env=vp&amp;output=xml_vast2&amp;unviewed_position_start=1&amp;url=dummy&amp;correlator=[timestamp]&amp;cmsid=133&amp;vid=10XWSh7W4so&amp;ad_rule=1</string>

--- a/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/README.md
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/README.md
@@ -6,6 +6,6 @@ Plays Widevine Modular DRM-protected Brightcove content with Google IMA ads sche
 
 | File | Responsibility |
 |---|---|
-| `AdRulesIMAWidevineModularActivity.kt` | Loads the Widevine-protected video from the `Catalog`, configures the Google IMA plugin with ad rules enabled, and answers the ad request with the configured VMAP ad tag URL. |
+| `MainActivity.kt` | Loads the Widevine-protected video from the `Catalog`, configures the Google IMA plugin with ad rules enabled, and answers the ad request with the configured VMAP ad tag URL. |
 
 See the [IMA ads README](../) for shared setup and requirements.

--- a/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
         <activity
-            android:name=".AdRulesIMAWidevineModularActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/adrulesimawidevinemodular/kotlin/MainActivity.kt
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/java/com/brightcove/player/samples/adrulesimawidevinemodular/kotlin/MainActivity.kt
@@ -19,22 +19,17 @@ import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
 /**
  * This app illustrates how to use "Ad Rules" with the Google IMA
  * plugin, the Widevine plugin, and the Brightcove Player for Android.
- * <p>
+ *
  * Note: Video cue points are not used with IMA Ad Rules. The AdCuePoints referenced
  * in the setupAdMarkers method below are Google IMA objects.
- * */
-
-class AdRulesIMAWidevineModularActivity : BrightcovePlayer() {
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityAdrulesImawidevineModularBinding
     private lateinit var eventEmitter: EventEmitter
     private lateinit var googleIMAComponent: GoogleIMAComponent
 
-    val TAG = this.javaClass.simpleName
-
     override fun onCreate(savedInstanceState: Bundle?) {
-
-        //Bind the views
         binding = ActivityAdrulesImawidevineModularBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -51,13 +46,11 @@ class AdRulesIMAWidevineModularActivity : BrightcovePlayer() {
         setupGoogleIMA()
 
         // Create the catalog object which will start and play the video.
-
-        // Create the catalog object which will start and play the video.
-        val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.account))
-            .setPolicy(getString(R.string.policy))
+        val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
 
@@ -80,8 +73,7 @@ class AdRulesIMAWidevineModularActivity : BrightcovePlayer() {
         // Establish the Google IMA SDK factory instance.
         val sdkFactory = ImaSdkFactory.getInstance()
 
-
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED) { event: Event ->
             Log.v(TAG, event.type)
         }
@@ -91,7 +83,7 @@ class AdRulesIMAWidevineModularActivity : BrightcovePlayer() {
             Log.v(TAG, event.type)
         }
 
-        // Enable Logging upon ad completion.
+        // Enable logging upon ad completion.
         eventEmitter.on(EventType.AD_COMPLETED) { event: Event ->
             Log.v(TAG, event.type)
         }
@@ -117,8 +109,9 @@ class AdRulesIMAWidevineModularActivity : BrightcovePlayer() {
         googleIMAComponent = GoogleIMAComponent.Builder(brightcoveVideoView, eventEmitter)
             .setUseAdRules(true)
             .build()
-
-        // Calling GoogleIMAComponent.initializeAdsRequests() is no longer necessary.
     }
 
+    companion object {
+        private const val TAG = "MainActivity"
+    }
 }

--- a/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/res/layout/activity_adrules_imawidevine_modular.xml
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/res/layout/activity_adrules_imawidevine_modular.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".AdRulesIMAWidevineModularActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/IMA/AdRulesIMAWidevineModularSampleApp-kotlin/src/main/res/values/strings.xml
@@ -4,13 +4,13 @@
     <string name="app_name">Ad Rules IMA Widevine Modular Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421543459001</string>
+    <string name="sdk_demo_video_id">5421543459001</string>
 
     <!-- A sample Brightcove ad rules URL -->
     <string name="adRulesUrl">http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&amp;iu=%2F15018773%2Feverything2&amp;ciu_szs=300x250%2C468x60%2C728x90&amp;impl=s&amp;gdfp_req=1&amp;env=vp&amp;output=xml_vast2&amp;unviewed_position_start=1&amp;url=dummy&amp;correlator=[timestamp]&amp;cmsid=133&amp;vid=10XWSh7W4so&amp;ad_rule=1</string>

--- a/IMA/BasicIMAVASTSampleApp-java/src/main/AndroidManifest.xml
+++ b/IMA/BasicIMAVASTSampleApp-java/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
         <activity
-            android:name="com.brightcove.player.samples.basicimavast.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/IMA/BasicIMAVASTSampleApp-java/src/main/java/com/brightcove/player/samples/basicimavast/java/MainActivity.java
+++ b/IMA/BasicIMAVASTSampleApp-java/src/main/java/com/brightcove/player/samples/basicimavast/java/MainActivity.java
@@ -35,12 +35,10 @@ import java.util.Map;
 /**
  * This app illustrates how to use the Google IMA plugin with the
  * Brightcove Player for Android.
- *
- * @author Jim Whisenant - ported from brightcove-mediaplayer samples
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     private static final int COMPANION_SLOT_WIDTH = 300;
     private static final int COMPANION_SLOT_HEIGHT = 250;
@@ -53,7 +51,7 @@ public class MainActivity extends BrightcovePlayer {
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the BrightcoveExoPlayerVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.ima_activity_main);
         brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
@@ -66,8 +64,8 @@ public class MainActivity extends BrightcovePlayer {
         // a playlist listener object for our sample video: the Potter Puppet show.
         setupGoogleIMA();
 
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.account_id))
-                .setPolicy(getString(R.string.policy_key))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         catalog.findVideoByReferenceID(getString(R.string.video_reference_id), new VideoListener() {
@@ -93,7 +91,7 @@ public class MainActivity extends BrightcovePlayer {
 
     /**
      * Specify where the ad should interrupt the main video.  This code provides a procedural
-     * abastraction for the Google IMA Plugin setup code.
+     * abstraction for the Google IMA Plugin setup code.
      */
     private void setupCuePoints(Source source) {
         CuePoint.CuePointType cuePointType = CuePoint.CuePointType.AD;

--- a/IMA/BasicIMAVASTSampleApp-java/src/main/res/values/strings.xml
+++ b/IMA/BasicIMAVASTSampleApp-java/src/main/res/values/strings.xml
@@ -2,8 +2,8 @@
 <resources>
 
     <string name="app_name">Basic IMA VAST Sample App</string>
-    <string name="account_id">5420904993001</string>
-    <string name="policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_account">5420904993001</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
     <string name="video_reference_id">dw_android_sdk_1_introduction</string>
 
 </resources>

--- a/IMA/BasicIMAVASTSampleApp-kotlin/README.md
+++ b/IMA/BasicIMAVASTSampleApp-kotlin/README.md
@@ -6,6 +6,6 @@ Plays a Brightcove video with Google IMA ads served from a single VAST ad tag. T
 
 | File | Responsibility |
 |---|---|
-| `BasicIMAVASTSampleActivity.kt` | Loads a video from the `Catalog`, sets preroll/midroll/postroll cue points, configures the Google IMA plugin, answers each ad request with the VAST ad tag, and wires up a companion ad slot. |
+| `MainActivity.kt` | Loads a video from the `Catalog`, sets preroll/midroll/postroll cue points, configures the Google IMA plugin, answers each ad request with the VAST ad tag, and wires up a companion ad slot. |
 
 See the [IMA ads README](../) for shared setup and requirements.

--- a/IMA/BasicIMAVASTSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/IMA/BasicIMAVASTSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Base.Theme.BasicIMAVASTSampleApp">
         <activity
-            android:name=".BasicIMAVASTSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/IMA/BasicIMAVASTSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicimavast/kotlin/MainActivity.kt
+++ b/IMA/BasicIMAVASTSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicimavast/kotlin/MainActivity.kt
@@ -3,7 +3,6 @@ package com.brightcove.player.samples.basicimavast.kotlin
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
-import android.view.ViewGroup
 import com.brightcove.ima.GoogleIMAComponent
 import com.brightcove.ima.GoogleIMAEventType
 import com.brightcove.player.appcompat.BrightcovePlayerActivity
@@ -24,7 +23,11 @@ import com.google.ads.interactivemedia.v3.api.AdsRequest
 import com.google.ads.interactivemedia.v3.api.CompanionAdSlot
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
 
-class BasicIMAVASTSampleActivity : BrightcovePlayerActivity() {
+/**
+ * This app illustrates how to use the Google IMA plugin with the
+ * Brightcove Player for Android.
+ */
+class MainActivity : BrightcovePlayerActivity() {
 
     private lateinit var binding: ActivityBasicImaVastBinding
     private lateinit var eventEmitter: EventEmitter
@@ -35,7 +38,7 @@ class BasicIMAVASTSampleActivity : BrightcovePlayerActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         // When extending the BrightcovePlayer, we must assign the BrightcoveExoPlayerVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         binding = ActivityBasicImaVastBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -48,8 +51,8 @@ class BasicIMAVASTSampleActivity : BrightcovePlayerActivity() {
         // Use a procedural abstraction to setup the Google IMA SDK via the plugin and establish
         // a playlist listener object for our sample video: the Potter Puppet show.
         setupGoogleIMA()
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.account_id))
-            .setPolicy(getString(R.string.policy_key))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         catalog.findVideoByReferenceID(getString(R.string.video_reference_id), object : VideoListener() {
@@ -77,28 +80,24 @@ class BasicIMAVASTSampleActivity : BrightcovePlayerActivity() {
      */
     private fun setupCuePoints(source: Source) {
         val cuePointType = CuePointType.AD
-        val properties: Map<String, Any> = HashMap()
-        val details: MutableMap<String, Any> = HashMap()
+        val properties = emptyMap<String, Any>()
 
         // preroll
         var cuePoint = CuePoint(CuePoint.PositionType.BEFORE, cuePointType, properties)
-        details[Event.CUE_POINT] = cuePoint
-        eventEmitter.emit(EventType.SET_CUE_POINT, details)
+        eventEmitter.emit(EventType.SET_CUE_POINT, mapOf(Event.CUE_POINT to cuePoint))
 
         // midroll at 30 seconds.
         if (source.deliveryType != DeliveryType.HLS) {
             val cuePointTime = (30 * DateUtils.SECOND_IN_MILLIS.toInt()).toLong()
             cuePoint = CuePoint(cuePointTime, cuePointType, properties)
-            details[Event.CUE_POINT] = cuePoint
-            eventEmitter.emit(EventType.SET_CUE_POINT, details)
+            eventEmitter.emit(EventType.SET_CUE_POINT, mapOf(Event.CUE_POINT to cuePoint))
             // Add a marker where the ad will be.
             mediaController.brightcoveSeekBar.addMarker(cuePointTime)
         }
 
         // postroll
         cuePoint = CuePoint(CuePoint.PositionType.AFTER, cuePointType, properties)
-        details[Event.CUE_POINT] = cuePoint
-        eventEmitter.emit(EventType.SET_CUE_POINT, details)
+        eventEmitter.emit(EventType.SET_CUE_POINT, mapOf(Event.CUE_POINT to cuePoint))
     }
 
     /**
@@ -168,7 +167,7 @@ class BasicIMAVASTSampleActivity : BrightcovePlayerActivity() {
     }
 
     companion object {
-        private val TAG = this::class.java.simpleName
+        private const val TAG = "MainActivity"
         private const val COMPANION_SLOT_WIDTH = 300
         private const val COMPANION_SLOT_HEIGHT = 250
     }

--- a/IMA/BasicIMAVASTSampleApp-kotlin/src/main/res/layout/activity_basic_ima_vast.xml
+++ b/IMA/BasicIMAVASTSampleApp-kotlin/src/main/res/layout/activity_basic_ima_vast.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical"
-    tools:context=".BasicIMAVASTSampleActivity" >
+    tools:context=".MainActivity" >
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/IMA/BasicIMAVASTSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/IMA/BasicIMAVASTSampleApp-kotlin/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">BasicIMAVASTSampleApp</string>
-    <string name="account_id">5420904993001</string>
-    <string name="policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_account">5420904993001</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
     <string name="video_reference_id">dw_android_sdk_1_introduction</string>
 </resources>

--- a/IMA/VideoListAdRulesIMASampleApp-java/README.md
+++ b/IMA/VideoListAdRulesIMASampleApp-java/README.md
@@ -7,6 +7,6 @@ Shows multiple independent Brightcove player instances in a scrolling list, wher
 | File | Responsibility |
 |---|---|
 | `MainActivity.java` | Hosts the `RecyclerView`, builds a `Catalog`, and loads a playlist by reference ID, handing its videos to the adapter. |
-| `AdapterView.java` | `RecyclerView.Adapter` that creates a `BrightcoveExoPlayerVideoView` per row, wires up the Google IMA ad-rules plugin with a VMAP ad tag, and starts/stops each player as rows attach and detach. |
+| `VideoListAdapter.java` | `RecyclerView.Adapter` that creates a `BrightcoveExoPlayerVideoView` per row, wires up the Google IMA ad-rules plugin with a VMAP ad tag, and starts/stops each player as rows attach and detach. |
 
 See the [IMA ads README](../) for shared setup and requirements.

--- a/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/MainActivity.java
+++ b/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/MainActivity.java
@@ -11,27 +11,30 @@ import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventEmitterImpl;
 import com.brightcove.player.model.Playlist;
 
+/**
+ * Fetches a Brightcove playlist and displays each video in a scrolling
+ * RecyclerView, with a dedicated player for every row.
+ */
 public class MainActivity extends AppCompatActivity {
 
     private Catalog catalog;
     private RecyclerView videoListView;
-    private AdapterView adapterView;
+    private VideoListAdapter adapterView;
 
     EventEmitter eventEmitter = new EventEmitterImpl();
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
-        videoListView = (RecyclerView) findViewById(R.id.video_list_view);
+        videoListView = findViewById(R.id.video_list_view);
 
-        adapterView = new AdapterView();
+        adapterView = new VideoListAdapter();
         videoListView.setAdapter(adapterView);
 
         catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.sdk_demo_policy_key))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         catalog.findPlaylistByReferenceID(getString(R.string.sdk_demo_playlist_reference), new PlaylistListener() {

--- a/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/VideoListAdapter.java
+++ b/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/VideoListAdapter.java
@@ -14,9 +14,7 @@ import android.widget.TextView;
 
 import com.brightcove.ima.GoogleIMAComponent;
 import com.brightcove.ima.GoogleIMAEventType;
-import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
-import com.brightcove.player.event.EventListener;
 import com.brightcove.player.event.EventType;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
@@ -27,10 +25,15 @@ import com.google.ads.interactivemedia.v3.api.ImaSdkFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
+/**
+ * RecyclerView adapter that gives each row its own BrightcoveExoPlayerVideoView
+ * and attaches the Google IMA ad-rules (VMAP) plugin per player.
+ */
+public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.ViewHolder> {
+
+    private static final String TAG = VideoListAdapter.class.getSimpleName();
 
     private final List<Video> videoList = new ArrayList<>();
-    private String adRulesURL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=";
 
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -40,7 +43,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        //Get Video information
         Video video = videoList.get(position);
         if (video != null) {
             holder.videoTitleText.setText(video.getStringProperty(Video.Fields.NAME));
@@ -53,11 +55,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
     @Override
     public int getItemCount() {
         return videoList.size();
-    }
-
-    @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
-        super.onAttachedToRecyclerView(recyclerView);
     }
 
     @Override
@@ -102,18 +99,15 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
             context = itemView.getContext();
-            videoFrame = (FrameLayout) itemView.findViewById(R.id.video_frame);
-            videoTitleText = (TextView) itemView.findViewById(R.id.video_title_text);
+            videoFrame = itemView.findViewById(R.id.video_frame);
+            videoTitleText = itemView.findViewById(R.id.video_title_text);
             videoView = new BrightcoveExoPlayerVideoView(context);
             videoFrame.addView(videoView);
             videoView.finishInitialization();
 
             EventEmitter eventEmitter = videoView.getEventEmitter();
-            eventEmitter.on(EventType.ENTER_FULL_SCREEN, new EventListener() {
-                @Override
-                public void processEvent(Event event) {
-                    //You can set listeners on each Video View
-                }
+            eventEmitter.on(EventType.ENTER_FULL_SCREEN, event -> {
+                // You can set listeners on each video view here.
             });
         }
     }
@@ -122,17 +116,16 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
      * Setup the Brightcove IMA Plugin.
      */
     private void setupGoogleIMA(EventEmitter eventEmitter, BrightcoveVideoView brightcoveVideoView) {
-        String TAG = "setupGoogleIMA";
         // Establish the Google IMA SDK factory instance.
         final ImaSdkFactory sdkFactory = ImaSdkFactory.getInstance();
 
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED, event -> Log.v(TAG, event.getType()));
 
         // Enable logging any failed attempts to play an ad.
         eventEmitter.on(GoogleIMAEventType.DID_FAIL_TO_PLAY_AD, event -> Log.v(TAG, event.getType()));
 
-        // Enable Logging upon ad completion.
+        // Enable logging upon ad completion.
         eventEmitter.on(EventType.AD_COMPLETED, event -> Log.v(TAG, event.getType()));
 
         // Set up a listener for initializing AdsRequests. The Google
@@ -142,7 +135,7 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
             // Build an ads request object and point it to the ad
             // display container created above.
             AdsRequest adsRequest = sdkFactory.createAdsRequest();
-            adsRequest.setAdTagUrl(adRulesURL);
+            adsRequest.setAdTagUrl(brightcoveVideoView.getContext().getString(R.string.adRulesUrl));
 
             ArrayList<AdsRequest> adsRequests = new ArrayList<>(1);
             adsRequests.add(adsRequest);

--- a/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/VideoListAdapter.java
+++ b/IMA/VideoListAdRulesIMASampleApp-java/src/main/java/com/brightcove/player/samples/videolistadrulesima/java/VideoListAdapter.java
@@ -2,7 +2,6 @@ package com.brightcove.player.samples.videolistadrulesima.java;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.util.Log;
@@ -83,7 +82,7 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
         }
     }
 
-    public void setVideoList(@Nullable List<Video> videoList) {
+    public void setVideoList(@NonNull List<Video> videoList) {
         this.videoList.clear();
         this.videoList.addAll(videoList);
         notifyDataSetChanged();

--- a/IMA/VideoListAdRulesIMASampleApp-java/src/main/res/values/strings.xml
+++ b/IMA/VideoListAdRulesIMASampleApp-java/src/main/res/values/strings.xml
@@ -6,10 +6,13 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
-    <!-- A sample Brightcove Video ID -->
+    <!-- A sample Brightcove playlist reference ID -->
     <string name="sdk_demo_playlist_reference">animal_videos</string>
+
+    <!-- Google IMA ad-rules (VMAP) ad tag URL -->
+    <string name="adRulesUrl">https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&amp;sz=640x480&amp;cust_params=sample_ct%3Dlinear&amp;ciu_szs=300x250%2C728x90&amp;gdfp_req=1&amp;output=vast&amp;unviewed_position_start=1&amp;env=vp&amp;impl=s&amp;correlator=</string>
 
     <string name="lorem_ipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
 

--- a/IMA/VideoListAdRulesIMASampleApp-kotlin/README.md
+++ b/IMA/VideoListAdRulesIMASampleApp-kotlin/README.md
@@ -7,6 +7,6 @@ Shows multiple independent Brightcove player instances in a scrolling list, wher
 | File | Responsibility |
 |---|---|
 | `MainActivity.kt` | Hosts the `RecyclerView`, builds a `Catalog`, and loads a playlist by reference ID, handing its videos to the adapter. |
-| `AdapterView.kt` | `RecyclerView.Adapter` that creates a `BrightcoveExoPlayerVideoView` per row, wires up the Google IMA ad-rules plugin with a VMAP ad tag, and starts/stops each player as rows attach and detach. |
+| `VideoListAdapter.kt` | `RecyclerView.Adapter` that creates a `BrightcoveExoPlayerVideoView` per row, wires up the Google IMA ad-rules plugin with a VMAP ad tag, and starts/stops each player as rows attach and detach. |
 
 See the [IMA ads README](../) for shared setup and requirements.

--- a/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolistadrulesima/kotlin/MainActivity.kt
+++ b/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolistadrulesima/kotlin/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.brightcove.player.samples.videolistadrulesima.kotlin
 
 import android.os.Bundle
-import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.brightcove.player.edge.Catalog
@@ -10,23 +9,26 @@ import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.event.EventEmitterImpl
 import com.brightcove.player.model.Playlist
 
+/**
+ * Fetches a Brightcove playlist and displays each video in a scrolling
+ * RecyclerView, with a dedicated player for every row.
+ */
 class MainActivity : AppCompatActivity() {
     private var catalog: Catalog? = null
     private var videoListView: RecyclerView? = null
-    private var adapterView: AdapterView? = null
+    private var adapterView: VideoListAdapter? = null
     private var eventEmitter: EventEmitter = EventEmitterImpl()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        videoListView = findViewById<View>(R.id.video_list_view) as RecyclerView
+        videoListView = findViewById(R.id.video_list_view)
 
-        adapterView = AdapterView()
+        adapterView = VideoListAdapter()
         videoListView?.setAdapter(adapterView)
 
         catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.sdk_demo_policy_key))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         catalog?.findPlaylistByReferenceID(

--- a/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolistadrulesima/kotlin/VideoListAdapter.kt
+++ b/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolistadrulesima/kotlin/VideoListAdapter.kt
@@ -19,10 +19,12 @@ import com.brightcove.player.view.BrightcoveVideoView
 import com.google.ads.interactivemedia.v3.api.AdsRequest
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
 
-class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
-    private val videoList: MutableList<Video> = ArrayList()
-    private val adRulesURL =
-        "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="
+/**
+ * RecyclerView adapter that gives each row its own BrightcoveExoPlayerVideoView
+ * and attaches the Google IMA ad-rules (VMAP) plugin per player.
+ */
+class VideoListAdapter : RecyclerView.Adapter<VideoListAdapter.ViewHolder>() {
+    private val videoList = mutableListOf<Video>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_view, parent, false)
@@ -30,7 +32,6 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        //Get Video information
         val video = videoList[position]
         holder.videoTitleText.text = video.getStringProperty(Video.Fields.NAME)
         val videoView = holder.videoView
@@ -72,10 +73,8 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val context: Context = itemView.context
-        val videoTitleText: TextView =
-            itemView.findViewById<View>(R.id.video_title_text) as TextView
-        private val videoFrame: FrameLayout =
-            itemView.findViewById<View>(R.id.video_frame) as FrameLayout
+        val videoTitleText: TextView = itemView.findViewById(R.id.video_title_text)
+        private val videoFrame: FrameLayout = itemView.findViewById(R.id.video_frame)
         val videoView: BrightcoveVideoView = BrightcoveExoPlayerVideoView(context)
 
         init {
@@ -84,7 +83,7 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
 
             val eventEmitter = videoView.eventEmitter
             eventEmitter.on(EventType.ENTER_FULL_SCREEN) {
-                //You can set listeners on each Video View
+                // You can set listeners on each video view here.
             }
         }
     }
@@ -96,11 +95,10 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
         eventEmitter: EventEmitter,
         brightcoveVideoView: BrightcoveVideoView
     ) {
-        val TAG = "setupGoogleIMA"
         // Establish the Google IMA SDK factory instance.
         val sdkFactory = ImaSdkFactory.getInstance()
 
-        // Enable logging up ad start.
+        // Enable logging upon ad start.
         eventEmitter.on(EventType.AD_STARTED) { event: Event ->
             Log.v(TAG, event.type)
         }
@@ -110,7 +108,7 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
             Log.v(TAG, event.type)
         }
 
-        // Enable Logging upon ad completion.
+        // Enable logging upon ad completion.
         eventEmitter.on(EventType.AD_COMPLETED) { event: Event ->
             Log.v(TAG, event.type)
         }
@@ -122,7 +120,7 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
             // Build an ads request object and point it to the ad
             // display container created above.
             val adsRequest = sdkFactory.createAdsRequest()
-            adsRequest.adTagUrl = adRulesURL
+            adsRequest.adTagUrl = brightcoveVideoView.context.getString(R.string.adRulesUrl)
 
             val adsRequests = ArrayList<AdsRequest>(1)
             adsRequests.add(adsRequest)
@@ -137,5 +135,9 @@ class AdapterView : RecyclerView.Adapter<AdapterView.ViewHolder>() {
         val googleIMAComponent = GoogleIMAComponent.Builder(brightcoveVideoView, eventEmitter)
             .setUseAdRules(true)
             .build()
+    }
+
+    companion object {
+        private const val TAG = "VideoListAdapter"
     }
 }

--- a/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/res/values/strings.xml
+++ b/IMA/VideoListAdRulesIMASampleApp-kotlin/src/main/res/values/strings.xml
@@ -5,10 +5,13 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
-    <!-- A sample Brightcove Video ID -->
+    <!-- A sample Brightcove playlist reference ID -->
     <string name="sdk_demo_playlist_reference">animal_videos</string>
+
+    <!-- Google IMA ad-rules (VMAP) ad tag URL -->
+    <string name="adRulesUrl">https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&amp;sz=640x480&amp;cust_params=sample_ct%3Dlinear&amp;ciu_szs=300x250%2C728x90&amp;gdfp_req=1&amp;output=vast&amp;unviewed_position_start=1&amp;env=vp&amp;impl=s&amp;correlator=</string>
 
     <string name="lorem_ipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
 

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/MainActivity.java
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/MainActivity.java
@@ -1,7 +1,6 @@
 package com.brightcove.player.samples.offlineplayback.java;
 
 import android.content.res.Configuration;
-import android.net.NetworkInfo;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,13 +9,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.text.format.Formatter;
 import android.util.Log;
 import android.view.View;
-import android.widget.ArrayAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.brightcove.player.display.ExoPlayerVideoDisplayComponent;
 import com.brightcove.player.edge.Catalog;
-import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.OfflineCallback;
 import com.brightcove.player.edge.OfflineCatalog;
 import com.brightcove.player.edge.OfflineStoreManager;
@@ -88,9 +85,6 @@ public class MainActivity extends BrightcovePlayer {
      */
     private ConnectivityMonitor connectivityMonitor;
 
-    /**
-     *
-     */
     private HttpRequestConfig httpRequestConfig;
     private String pasToken = "YOUR_PAS_TOKEN";
     private static final int PLAYDURATION_EXTENSION = 10000;
@@ -110,11 +104,6 @@ public class MainActivity extends BrightcovePlayer {
         super.onStart();
         ConnectivityMonitor.getInstance(this).addListener(connectivityListener);
         catalog.addDownloadEventListener(downloadEventListener);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
     }
 
     @Override
@@ -142,7 +131,7 @@ public class MainActivity extends BrightcovePlayer {
 
         catalog = new OfflineCatalog.Builder(this,eventEmitter, getString(R.string.sdk_demo_account))
                 .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.sdk_demo_policy_key))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         //Configure downloads through the catalog.
@@ -155,12 +144,6 @@ public class MainActivity extends BrightcovePlayer {
         // Connect the video list view to the adapter
         RecyclerView videoListView = ViewUtil.findView(this, R.id.video_list_view);
         videoListView.setAdapter(videoListAdapter);
-
-        // Setup an adapter to render the playlist items in the spinner view Adapter that
-        // will be used to bind the playlist spinner to the underlying data source.
-        ArrayAdapter<PlaylistModel> playlistAdapter = new ArrayAdapter<>(this,
-                android.R.layout.simple_spinner_item/*, playlistNames*/);
-        playlistAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
         ExoPlayerVideoDisplayComponent videoDisplayComponent = ((ExoPlayerVideoDisplayComponent) brightcoveVideoView.getVideoDisplay());
         if (videoDisplayComponent != null) {
@@ -186,11 +169,6 @@ public class MainActivity extends BrightcovePlayer {
                     videoListAdapter.setVideoList(playlist.getVideos());
                     onVideoListUpdated(false);
                     brightcoveVideoView.addAll(playlist.getVideos());
-                }
-
-                @Override
-                public void onError(List<CatalogError> errors) {
-                    super.onError(errors);
                 }
             });
         } else {
@@ -354,11 +332,8 @@ public class MainActivity extends BrightcovePlayer {
      * Implements a {@link com.brightcove.player.network.ConnectivityMonitor.Listener} that will
      * update the current video list based on network connectivity state.
      */
-    private final ConnectivityMonitor.Listener connectivityListener = new ConnectivityMonitor.Listener() {
-        public void onConnectivityChanged(boolean connected, @Nullable NetworkInfo networkInfo) {
-            updateVideoList();
-        }
-    };
+    private final ConnectivityMonitor.Listener connectivityListener =
+            (connected, networkInfo) -> updateVideoList();
 
     /**
      * Implements a {@link VideoListListener} that responds to user interaction on the video list.
@@ -475,7 +450,7 @@ public class MainActivity extends BrightcovePlayer {
      *
      * @param video the video to be played.
      */
-    private void playVideo(@NonNull Video video, @NonNull int videoIndex) {
+    private void playVideo(@NonNull Video video, int videoIndex) {
         brightcoveVideoView.replace(videoIndex, video);
         brightcoveVideoView.setCurrentIndex(videoIndex);
         brightcoveVideoView.start();
@@ -499,7 +474,7 @@ public class MainActivity extends BrightcovePlayer {
                 case EventType.ODRM_PLAYBACK_NOT_ALLOWED:
                 case EventType.ODRM_SOURCE_NOT_FOUND: {
                     String message = showToast(
-                            "Failed to downloaded license for '%s' video: %s", video.getName(), type);
+                            "Failed to download license for '%s' video: %s", video.getName(), type);
                     Log.w(TAG, message);
                     break;
                 }
@@ -572,11 +547,6 @@ public class MainActivity extends BrightcovePlayer {
          */
         FindVideoListener(Video video) {
             this.video = video;
-        }
-
-        @Override
-        public void onError(List<CatalogError> errors) {
-            super.onError(errors);
         }
     }
 

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/VideoListAdapter.java
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/VideoListAdapter.java
@@ -188,7 +188,7 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
     private final VideoListListener listener;
 
     /**
-     * Constructors a new video list adapter.
+     * Constructs a new video list adapter.
      *
      * @param catalog  reference to the offline catalog.
      * @param listener reference to a listener

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/utils/BrightcoveDownloadUtil.java
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/utils/BrightcoveDownloadUtil.java
@@ -31,7 +31,7 @@ public class BrightcoveDownloadUtil {
      * @param bundle            - The app bundle
      */
     public static void selectMediaFormatTracksAvailable(MediaDownloadable mediaDownloadable, Bundle bundle) {
-        boolean didListChange;
+        boolean didListChange = false;
 
         ArrayList<MediaFormat> audio = bundle.getParcelableArrayList(MediaDownloadable.AUDIO_LANGUAGES);
         int indexMain = -1;
@@ -42,10 +42,12 @@ public class BrightcoveDownloadUtil {
             Log.v(TAG, "Adding the \"main\" audio track.");
             //First let's find the index of the audio with role main
             ArrayList<String> roles = bundle.getStringArrayList(MediaDownloadable.AUDIO_LANGUAGE_ROLES);
-            for (int i = 0; i < roles.size(); i++) {
-                if ("main".equalsIgnoreCase(roles.get(i))) {
-                    indexMain = i;
-                    break;
+            if (roles != null) {
+                for (int i = 0; i < roles.size(); i++) {
+                    if ("main".equalsIgnoreCase(roles.get(i))) {
+                        indexMain = i;
+                        break;
+                    }
                 }
             }
 
@@ -56,31 +58,31 @@ public class BrightcoveDownloadUtil {
 
             //Select main
             newAudio.add(audio.get(indexMain));
-        }
 
-        // Now select the "extra" audio track
-        // In an effort to avoid over-complication of the flow of this demonstration app, we make an assumption here
-        // that the end user has selected the first of the remaining audio tracks that is not the "main" audio track
-        // (if more than one audio track is present)
-        if (audio.size() > 1) {
-            Log.v(TAG, "Alternate audio track download allowed for this video. Adding an \"alternate\" audio track");
-            for (MediaFormat audioTrack : audio) {
-                if (indexMain != audio.indexOf(audioTrack)){
-                    newAudio.add(audioTrack);
+            // Now select the "extra" audio track
+            // In an effort to avoid over-complication of the flow of this demonstration app, we make an assumption here
+            // that the end user has selected the first of the remaining audio tracks that is not the "main" audio track
+            // (if more than one audio track is present)
+            if (audio.size() > 1) {
+                Log.v(TAG, "Alternate audio track download allowed for this video. Adding an \"alternate\" audio track");
+                for (MediaFormat audioTrack : audio) {
+                    if (indexMain != audio.indexOf(audioTrack)){
+                        newAudio.add(audioTrack);
+                    }
                 }
+            } else {
+                Log.v(TAG, "Alternate audio track download allowed, but there were no \"alternate\" audio tracks to select.");
             }
-        } else {
-            Log.v(TAG, "Alternate audio track download allowed, but there were no \"alternate\" audio tracks to select.");
+            bundle.putParcelableArrayList(MediaDownloadable.AUDIO_LANGUAGES, newAudio);
+            didListChange = true;
         }
-        bundle.putParcelableArrayList(MediaDownloadable.AUDIO_LANGUAGES, newAudio);
-        didListChange = true;
 
         // All captions are considered "extra" tracks for download
         // As with the alternate audio track selection above, we make an assumption here that the end user has selected the
         // first caption track as the "default" caption language, and the second caption track as the "alternate" (if more than
         // one caption track is present)
         ArrayList<MediaFormat> captions = bundle.getParcelableArrayList(MediaDownloadable.CAPTIONS);
-        Log.v(TAG, "Captions array size: " + captions.size());
+        Log.v(TAG, "Captions array size: " + (captions != null ? captions.size() : 0));
         if (captions != null && captions.size() > 0) {
             ArrayList<MediaFormat> newCaptions = new ArrayList<>();
             Log.v(TAG, "Adding the first caption track as the \"default\" caption track.");

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/utils/ViewUtil.java
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/java/com/brightcove/player/samples/offlineplayback/java/utils/ViewUtil.java
@@ -6,13 +6,11 @@ import android.view.View;
 
 /**
  * Provides utility methods to work with Android {@link android.view.View}.
- *
- * @author rsubramaniam (rsubramaniam@brightcove.com)
  */
 public final class ViewUtil {
 
     /**
-     * Prevents contruction of this utility class.
+     * Prevents construction of this utility class.
      */
     private ViewUtil() {
         // Nothing to do

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/res/values/strings.xml
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="sdk_demo_account" translatable="false">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key" translatable="false">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy" translatable="false">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
     <string name="sdk_demo_playlist_reference" translatable="false">demo_odrm_widevine_dash</string>

--- a/Offline/OfflinePlaybackSampleApp-java/src/main/res/values/strings.xml
+++ b/Offline/OfflinePlaybackSampleApp-java/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <!-- A sample Brightcove Edge Policy Key -->
     <string name="sdk_demo_policy" translatable="false">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
-    <!-- A sample Brightcove Video ID -->
+    <!-- A sample Brightcove playlist reference ID -->
     <string name="sdk_demo_playlist_reference" translatable="false">demo_odrm_widevine_dash</string>
 
     <!-- Fetching playlist-->

--- a/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/MainActivity.kt
+++ b/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/MainActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.text.format.Formatter
 import android.util.Log
 import android.view.View
-import android.widget.ArrayAdapter
 import android.widget.TextView
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
@@ -13,7 +12,6 @@ import com.brightcove.player.samples.offlineplayback.kotlin.utils.BrightcoveDown
 import com.brightcove.player.samples.offlineplayback.kotlin.utils.ViewUtil
 import com.brightcove.player.display.ExoPlayerVideoDisplayComponent
 import com.brightcove.player.edge.Catalog
-import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.OfflineCallback
 import com.brightcove.player.edge.OfflineCatalog
 import com.brightcove.player.edge.OfflineStoreManager
@@ -33,6 +31,9 @@ import java.io.Serializable
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
+/**
+ * An activity that displays a list of videos that can be downloaded.
+ */
 class MainActivity : BrightcovePlayer() {
     /**
      * Specifies how long the content can be consumed after the start of playback as total number
@@ -112,7 +113,7 @@ class MainActivity : BrightcovePlayer() {
 
         catalog = OfflineCatalog.Builder(this, eventEmitter, getString(R.string.sdk_demo_account))
             .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.sdk_demo_policy_key))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         //Configure downloads through the catalog.
@@ -125,12 +126,6 @@ class MainActivity : BrightcovePlayer() {
         // Connect the video list view to the adapter
         val videoListView: RecyclerView = ViewUtil.findView(this, R.id.video_list_view)
         videoListView.adapter = videoListAdapter
-
-        // Setup an adapter to render the playlist items in the spinner view Adapter that
-        // will be used to bind the playlist spinner to the underlying data source.
-        val playlistAdapter: ArrayAdapter<PlaylistModel> =
-            ArrayAdapter(this, android.R.layout.simple_spinner_item /*, playlistNames*/)
-        playlistAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
 
         val videoDisplayComponent =
             brightcoveVideoView.videoDisplay as ExoPlayerVideoDisplayComponent
@@ -154,10 +149,6 @@ class MainActivity : BrightcovePlayer() {
                     videoListAdapter?.setVideoList(playlist.videos)
                     onVideoListUpdated(false)
                     brightcoveVideoView.addAll(playlist.videos)
-                }
-
-                override fun onError(errors: List<CatalogError>) {
-                    super.onError(errors)
                 }
             })
         } else {
@@ -435,7 +426,7 @@ class MainActivity : BrightcovePlayer() {
                 }
 
                 EventType.ODRM_PLAYBACK_NOT_ALLOWED, EventType.ODRM_SOURCE_NOT_FOUND -> {
-                    val message = "Failed to downloaded license for '${video?.name}' video: $type"
+                    val message = "Failed to download license for '${video?.name}' video: $type"
                     showToast(message)
                     Log.w(TAG, message)
                 }
@@ -502,9 +493,9 @@ class MainActivity : BrightcovePlayer() {
          */
         private val video: Video
     ) :
-        VideoListener() {
-        override fun onError(errors: List<CatalogError>) {
-            super.onError(errors)
-        }
+        VideoListener()
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/VideoListAdapter.kt
+++ b/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/VideoListAdapter.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit
  */
 class VideoListAdapter
 /**
- * Constructors a new video list adapter.
+ * Constructs a new video list adapter.
  *
  * @param catalog  reference to the offline catalog.
  * @param listener reference to a listener

--- a/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/utils/BrightcoveDownloadUtil.kt
+++ b/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/utils/BrightcoveDownloadUtil.kt
@@ -23,7 +23,7 @@ object BrightcoveDownloadUtil {
      * @param bundle            - The app bundle
      */
     fun selectMediaFormatTracksAvailable(mediaDownloadable: MediaDownloadable, bundle: Bundle) {
-        var didListChange: Boolean
+        var didListChange = false
 
         val audio = bundle.getParcelableArrayList<MediaFormat>(MediaDownloadable.AUDIO_LANGUAGES)
         var indexMain = -1
@@ -51,24 +51,24 @@ object BrightcoveDownloadUtil {
 
             //Select main
             newAudio.add(audio[indexMain])
-        }
 
-        // Now select the "extra" audio track
-        // In an effort to avoid over-complication of the flow of this demonstration app, we make an assumption here
-        // that the end user has selected the first of the remaining audio tracks that is not the "main" audio track
-        // (if more than one audio track is present)
-        if (audio != null && audio.size > 1) {
-            Log.v(TAG, "Alternate audio track download allowed for this video. Adding an \"alternate\" audio track")
-            for (audioTrack in audio) {
-                if (indexMain != audio.indexOf(audioTrack)) {
-                    newAudio.add(audioTrack)
+            // Now select the "extra" audio track
+            // In an effort to avoid over-complication of the flow of this demonstration app, we make an assumption here
+            // that the end user has selected the first of the remaining audio tracks that is not the "main" audio track
+            // (if more than one audio track is present)
+            if (audio.size > 1) {
+                Log.v(TAG, "Alternate audio track download allowed for this video. Adding an \"alternate\" audio track")
+                for (audioTrack in audio) {
+                    if (indexMain != audio.indexOf(audioTrack)) {
+                        newAudio.add(audioTrack)
+                    }
                 }
+            } else {
+                Log.v(TAG, "Alternate audio track download allowed, but there were no \"alternate\" audio tracks to select.")
             }
-        } else {
-            Log.v(TAG, "Alternate audio track download allowed, but there were no \"alternate\" audio tracks to select.")
+            bundle.putParcelableArrayList(MediaDownloadable.AUDIO_LANGUAGES, newAudio)
+            didListChange = true
         }
-        bundle.putParcelableArrayList(MediaDownloadable.AUDIO_LANGUAGES, newAudio)
-        didListChange = true
 
         // All captions are considered "extra" tracks for download
         // As with the alternate audio track selection above, we make an assumption here that the end user has selected the

--- a/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/utils/ViewUtil.kt
+++ b/Offline/OfflinePlaybackSampleApp-kotlin/src/main/java/com/brightcove/player/samples/offlineplayback/kotlin/utils/ViewUtil.kt
@@ -5,8 +5,6 @@ import android.view.View
 
 /**
  * Provides utility methods to work with Android [View].
- *
- * @author rsubramaniam (rsubramaniam@brightcove.com)
  */
 object ViewUtil {
     /**

--- a/Offline/OfflinePlaybackSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Offline/OfflinePlaybackSampleApp-kotlin/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="sdk_demo_account" translatable="false">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key" translatable="false">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy" translatable="false">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- Fetching playlist-->
     <string name="fetching_playlist">Fetching Playlist&#8230;</string>

--- a/Player/360VideoSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/360VideoSampleApp-java/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.video360.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/360VideoSampleApp-java/src/main/java/com/brightcove/player/samples/video360/java/MainActivity.java
+++ b/Player/360VideoSampleApp-java/src/main/java/com/brightcove/player/samples/video360/java/MainActivity.java
@@ -3,35 +3,44 @@ package com.brightcove.player.samples.video360.java;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
+import java.util.List;
+
+/**
+ * This app illustrates how to play a 360 (equirectangular) video with the Brightcove
+ * Native Player SDK for Android.
+ */
 public class MainActivity extends BrightcovePlayer {
+
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override
     @SuppressWarnings("ResourceType")
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         EventEmitter eventEmitter = brightcoveVideoView.getEventEmitter();
-        String account = getString(R.string.account);
+        String account = getString(R.string.sdk_demo_account);
 
         Catalog catalog = new Catalog.Builder(eventEmitter, account)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.policy))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             @Override
             public void onVideo(Video video) {
                 Video.ProjectionFormat projectionFormat = video.getProjectionFormat();
@@ -41,9 +50,15 @@ public class MainActivity extends BrightcovePlayer {
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
             }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
+            }
         });
-        //You can also create a 360 video by setting the the projection field on creation as shown below:
-        //Video video = Video.createVideo(VIDEO_URL, VIDEO_TYPE, PROJECTION_FORMAT);
+        // Uncomment to try: create a 360 video directly by setting the projection format,
+        // instead of fetching it from the Catalog:
+        // Video video = Video.createVideo(VIDEO_URL, VIDEO_TYPE, PROJECTION_FORMAT);
     }
 
 }

--- a/Player/360VideoSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/360VideoSampleApp-java/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <!-- Application name -->
     <string name="app_name">360 Video Demo</string>
 
-    <string name="account">3636334163001</string>
-    <string name="policy">BCpkADawqM1W-vUOMe6RSA3pA6Vw-VWUNn5rL0lzQabvrI63-VjS93gVUugDlmBpHIxP16X8TSe5LSKM415UHeMBmxl7pqcwVY_AZ4yKFwIpZPvXE34TpXEYYcmulxJQAOvHbv2dpfq-S_cm</string>
-    <string name="videoId">5240309173001</string>
+    <string name="sdk_demo_account">3636334163001</string>
+    <string name="sdk_demo_policy">BCpkADawqM1W-vUOMe6RSA3pA6Vw-VWUNn5rL0lzQabvrI63-VjS93gVUugDlmBpHIxP16X8TSe5LSKM415UHeMBmxl7pqcwVY_AZ4yKFwIpZPvXE34TpXEYYcmulxJQAOvHbv2dpfq-S_cm</string>
+    <string name="sdk_demo_video_id">5240309173001</string>
 </resources>

--- a/Player/360VideoSampleApp-kotlin/README.md
+++ b/Player/360VideoSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Plays a 360° equirectangular video, which the SDK renders with touch and gyrosc
 
 | File | Responsibility |
 |---|---|
-| `Video360Activity.kt` | Fetches the video, detects its equirectangular projection, and starts playback. |
+| `MainActivity.kt` | Fetches the video, detects its equirectangular projection, and starts playback. |
 | `res/layout/activity_main.xml` | Screen layout hosting the `BrightcoveExoPlayerVideoView`. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/360VideoSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/360VideoSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name=".Video360Activity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/360VideoSampleApp-kotlin/src/main/java/com/brightcove/player/samples/video360/kotlin/MainActivity.kt
+++ b/Player/360VideoSampleApp-kotlin/src/main/java/com/brightcove/player/samples/video360/kotlin/MainActivity.kt
@@ -3,6 +3,7 @@ package com.brightcove.player.samples.video360.kotlin
 import android.os.Bundle
 import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayer
@@ -12,7 +13,7 @@ import com.brightcove.player.samples.video360.kotlin.databinding.ActivityMainBin
  * This app illustrates how to play a 360 (equirectangular) video with the Brightcove
  * Native Player SDK for Android.
  */
-class Video360Activity : BrightcovePlayer() {
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityMainBinding
 
@@ -24,12 +25,11 @@ class Video360Activity : BrightcovePlayer() {
         brightcoveVideoView = binding.brightcoveVideoView
         super.onCreate(savedInstanceState)
 
-        val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.policy))
+        val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 if (video.projectionFormat == Video.ProjectionFormat.EQUIRECTANGULAR) {
                     Log.i(TAG, "This is a 360 video")
@@ -37,8 +37,17 @@ class Video360Activity : BrightcovePlayer() {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
-        // You can also create a 360 video by setting the projection format on creation:
+        // Uncomment to try: create a 360 video directly by setting the projection format,
+        // instead of fetching it from the Catalog:
         // val video = Video.createVideo(VIDEO_URL, VIDEO_TYPE, PROJECTION_FORMAT)
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/360VideoSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/360VideoSampleApp-kotlin/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <!-- Application name -->
     <string name="app_name">360 Video Demo</string>
 
-    <string name="account">3636334163001</string>
-    <string name="policy">BCpkADawqM1W-vUOMe6RSA3pA6Vw-VWUNn5rL0lzQabvrI63-VjS93gVUugDlmBpHIxP16X8TSe5LSKM415UHeMBmxl7pqcwVY_AZ4yKFwIpZPvXE34TpXEYYcmulxJQAOvHbv2dpfq-S_cm</string>
-    <string name="videoId">5240309173001</string>
+    <string name="sdk_demo_account">3636334163001</string>
+    <string name="sdk_demo_policy">BCpkADawqM1W-vUOMe6RSA3pA6Vw-VWUNn5rL0lzQabvrI63-VjS93gVUugDlmBpHIxP16X8TSe5LSKM415UHeMBmxl7pqcwVY_AZ4yKFwIpZPvXE34TpXEYYcmulxJQAOvHbv2dpfq-S_cm</string>
+    <string name="sdk_demo_video_id">5240309173001</string>
 </resources>

--- a/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/AppCompatPlayerActivity.java
+++ b/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/AppCompatPlayerActivity.java
@@ -14,9 +14,9 @@ public class AppCompatPlayerActivity extends BrightcovePlayerActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_player);
 
-        Video video = Video.createVideo("https://media.w3.org/2010/05/sintel/trailer.mp4", DeliveryType.MP4);
+        Video video = Video.createVideo(getString(R.string.sdk_demo_video_url), DeliveryType.MP4);
         baseVideoView.add(video);
-        baseVideoView.getAnalytics().setAccount("1760897681001");
+        baseVideoView.getAnalytics().setAccount(getString(R.string.sdk_demo_account));
         baseVideoView.start();
     }
 }

--- a/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/FragmentPlayerActivity.java
+++ b/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/FragmentPlayerActivity.java
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
  */
 public class FragmentPlayerActivity extends AppCompatActivity {
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_fragment);
     }

--- a/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/PlayerFragment.java
+++ b/Player/AppCompatSampleApp-java/src/main/java/com/brightcove/player/samples/appcompat/java/PlayerFragment.java
@@ -7,21 +7,21 @@ import android.view.ViewGroup;
 import com.brightcove.player.appcompat.BrightcovePlayerFragment;
 import com.brightcove.player.model.DeliveryType;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BaseVideoView;
 
+/**
+ * BrightcovePlayerFragment that loads and plays the sample video.
+ */
 public class PlayerFragment extends BrightcovePlayerFragment {
-
-    public static final String TAG = PlayerFragment.class.getSimpleName();
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View result = inflater.inflate(R.layout.fragment_player, container, false);
-        baseVideoView = (BaseVideoView) result.findViewById(R.id.brightcove_video_view);
+        baseVideoView = result.findViewById(R.id.brightcove_video_view);
         super.onCreateView(inflater, container, savedInstanceState);
 
-        Video video = Video.createVideo("https://media.w3.org/2010/05/sintel/trailer.mp4", DeliveryType.MP4);
+        Video video = Video.createVideo(getString(R.string.sdk_demo_video_url), DeliveryType.MP4);
         baseVideoView.add(video);
-        baseVideoView.getAnalytics().setAccount("1760897681001");
+        baseVideoView.getAnalytics().setAccount(getString(R.string.sdk_demo_account));
         baseVideoView.start();
 
         return result;

--- a/Player/AppCompatSampleApp-java/src/main/res/layout/fragment_player.xml
+++ b/Player/AppCompatSampleApp-java/src/main/res/layout/fragment_player.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".MainFragment">
+    tools:context=".PlayerFragment">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/AppCompatSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/AppCompatSampleApp-java/src/main/res/values/strings.xml
@@ -6,4 +6,10 @@
     <string name="activity_example">Activity example</string>
     <string name="fragment_example">Fragment example</string>
 
+    <!-- A sample Brightcove Edge Account ID -->
+    <string name="sdk_demo_account">1760897681001</string>
+
+    <!-- A sample video URL -->
+    <string name="sdk_demo_video_url">https://media.w3.org/2010/05/sintel/trailer.mp4</string>
+
 </resources>

--- a/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/AppCompatPlayerActivity.kt
+++ b/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/AppCompatPlayerActivity.kt
@@ -19,11 +19,11 @@ class AppCompatPlayerActivity : BrightcovePlayerActivity() {
         binding = ActivityPlayerBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val video = Video.createVideo("https://media.w3.org/2010/05/sintel/trailer.mp4", DeliveryType.MP4)
+        val video = Video.createVideo(getString(R.string.sdk_demo_video_url), DeliveryType.MP4)
 
         baseVideoView.apply {
             add(video)
-            analytics.account = "1760897681001"
+            analytics.account = getString(R.string.sdk_demo_account)
             start()
         }
     }

--- a/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/PlayerFragment.kt
+++ b/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/PlayerFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.brightcove.player.samples.appcompat.kotlin.databinding.FragmentAppCompatBinding
+import com.brightcove.player.appcompat.BrightcovePlayerFragment
 import com.brightcove.player.model.DeliveryType
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcovePlayerFragment
+import com.brightcove.player.samples.appcompat.kotlin.databinding.FragmentAppCompatBinding
 
 /**
  * BrightcovePlayerFragment that loads and plays the sample video.
@@ -19,7 +19,7 @@ class PlayerFragment : BrightcovePlayerFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
 
         binding = FragmentAppCompatBinding.inflate(inflater, container, false)
-        brightcoveVideoView = binding.brightcoveVideoView
+        baseVideoView = binding.brightcoveVideoView
 
         super.onCreateView(inflater, container, savedInstanceState)
         val video = Video.createVideo(getString(R.string.sdk_demo_video_url), DeliveryType.MP4)

--- a/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/PlayerFragment.kt
+++ b/Player/AppCompatSampleApp-kotlin/src/main/java/com/brightcove/player/samples/appcompat/kotlin/PlayerFragment.kt
@@ -9,6 +9,9 @@ import com.brightcove.player.model.DeliveryType
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayerFragment
 
+/**
+ * BrightcovePlayerFragment that loads and plays the sample video.
+ */
 class PlayerFragment : BrightcovePlayerFragment() {
 
     private lateinit var binding: FragmentAppCompatBinding
@@ -19,9 +22,9 @@ class PlayerFragment : BrightcovePlayerFragment() {
         brightcoveVideoView = binding.brightcoveVideoView
 
         super.onCreateView(inflater, container, savedInstanceState)
-        val video = Video.createVideo("https://media.w3.org/2010/05/sintel/trailer.mp4", DeliveryType.MP4)
+        val video = Video.createVideo(getString(R.string.sdk_demo_video_url), DeliveryType.MP4)
         baseVideoView.add(video)
-        baseVideoView.analytics.account = "1760897681001"
+        baseVideoView.analytics.account = getString(R.string.sdk_demo_account)
         baseVideoView.start()
         return binding.root
     }

--- a/Player/AppCompatSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/AppCompatSampleApp-kotlin/src/main/res/values/strings.xml
@@ -6,4 +6,10 @@
     <string name="activity_example">Activity example</string>
     <string name="fragment_example">Fragment example</string>
 
+    <!-- A sample Brightcove Edge Account ID -->
+    <string name="sdk_demo_account">1760897681001</string>
+
+    <!-- A sample video URL -->
+    <string name="sdk_demo_video_url">https://media.w3.org/2010/05/sintel/trailer.mp4</string>
+
 </resources>

--- a/Player/AudioOnlySampleApp-java/README.md
+++ b/Player/AudioOnlySampleApp-java/README.md
@@ -10,6 +10,6 @@ Plays audio-only assets with a media-style background playback notification, so 
 | File | Responsibility |
 |---|---|
 | `MainActivity.java` | Loads the playlist via `Catalog`, wires the shuffle and repeat controls, and attaches the background playback notification. |
-| `AdapterView.java` | RecyclerView adapter listing the tracks; a tap switches the playing track. |
+| `VideoListAdapter.java` | RecyclerView adapter listing the tracks; a tap switches the playing track. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/MainActivity.java
+++ b/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/MainActivity.java
@@ -19,11 +19,15 @@ import com.brightcove.player.playback.PlaybackNotificationConfig;
 import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
+/**
+ * Demonstrates audio-only playback: a Brightcove playlist of audio tracks played with a
+ * media-style background playback notification, plus shuffle and repeat controls.
+ */
 public class MainActivity extends BrightcovePlayer {
 
     private BrightcoveExoPlayerVideoView brightcoveVideoView;
     private RecyclerView videoListView;
-    private AdapterView adapterView;
+    private VideoListAdapter videoListAdapter;
 
     private String accountId;
     private String policyKey;
@@ -35,8 +39,8 @@ public class MainActivity extends BrightcovePlayer {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        accountId = getString(R.string.account);
-        policyKey = getString(R.string.policy);
+        accountId = getString(R.string.sdk_demo_account);
+        policyKey = getString(R.string.sdk_demo_policy);
         playListReference = getString(R.string.trackPlaylistReference);
 
         usePlaylist();
@@ -66,27 +70,23 @@ public class MainActivity extends BrightcovePlayer {
         setContentView(R.layout.activity_main_playlist);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view_playlist);
         videoListView = findViewById(R.id.video_list_view);
-        adapterView = new AdapterView(brightcoveVideoView);
-        videoListView.setAdapter(adapterView);
+        videoListAdapter = new VideoListAdapter(brightcoveVideoView);
+        videoListView.setAdapter(videoListAdapter);
         catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), accountId)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(policyKey)
                 .build();
         catalog.findPlaylistByReferenceID(playListReference, new PlaylistListener() {
             @Override
             public void onPlaylist(Playlist playlist) {
                 brightcoveVideoView.addAll(playlist.getVideos());
-                adapterView.setVideoList(playlist.getVideos());
+                videoListAdapter.setVideoList(playlist.getVideos());
                 brightcoveVideoView.start();
             }
         });
         ImageButton actionGitHubButton = findViewById(R.id.action_github);
-        actionGitHubButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.GITHUB_URL)));
-                startActivity(browserIntent);
-            }
+        actionGitHubButton.setOnClickListener(v -> {
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.GITHUB_URL)));
+            startActivity(browserIntent);
         });
     }
 

--- a/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/MainActivity.java
+++ b/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/MainActivity.java
@@ -25,7 +25,6 @@ import com.brightcove.player.view.BrightcovePlayer;
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private BrightcoveExoPlayerVideoView brightcoveVideoView;
     private RecyclerView videoListView;
     private VideoListAdapter videoListAdapter;
 
@@ -38,7 +37,12 @@ public class MainActivity extends BrightcovePlayer {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
+        // entering the superclass. This allows for some stock video player lifecycle management.
+        setContentView(R.layout.activity_main_playlist);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view_playlist);
         super.onCreate(savedInstanceState);
+
         accountId = getString(R.string.sdk_demo_account);
         policyKey = getString(R.string.sdk_demo_policy);
         playListReference = getString(R.string.trackPlaylistReference);
@@ -67,10 +71,8 @@ public class MainActivity extends BrightcovePlayer {
      * Loads a playlist of audio tracks and shows them in a list beside the player.
      */
     private void usePlaylist() {
-        setContentView(R.layout.activity_main_playlist);
-        brightcoveVideoView = findViewById(R.id.brightcove_video_view_playlist);
         videoListView = findViewById(R.id.video_list_view);
-        videoListAdapter = new VideoListAdapter(brightcoveVideoView);
+        videoListAdapter = new VideoListAdapter((BrightcoveExoPlayerVideoView) brightcoveVideoView);
         videoListView.setAdapter(videoListAdapter);
         catalog = new Catalog.Builder(brightcoveVideoView.getEventEmitter(), accountId)
                 .setPolicy(policyKey)

--- a/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/VideoListAdapter.java
+++ b/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/VideoListAdapter.java
@@ -2,6 +2,7 @@ package com.brightcove.player.samples.audioonly.java;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,7 +14,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.brightcove.player.logging.Log;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 
@@ -26,14 +26,17 @@ import coil3.request.ImageRequest;
 import coil3.target.ImageViewTarget;
 
 
-public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
+/**
+ * RecyclerView adapter that lists the audio tracks in the playlist; tapping a row
+ * switches the {@link BrightcoveExoPlayerVideoView} to that track.
+ */
+public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.ViewHolder> {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = VideoListAdapter.class.getSimpleName();
     private final BrightcoveExoPlayerVideoView brightcoveVideoView;
     private final List<Video> videoList = new ArrayList<>();
 
-
-    public AdapterView (BrightcoveExoPlayerVideoView videoView) {
+    public VideoListAdapter(BrightcoveExoPlayerVideoView videoView) {
         brightcoveVideoView = videoView;
     }
 
@@ -46,7 +49,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        //Get track information
         Video video = videoList.get(position);
 
         if (video != null) {
@@ -81,26 +83,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
     @Override
     public int getItemCount() {
         return videoList.size();
-    }
-
-    @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
-        super.onAttachedToRecyclerView(recyclerView);
-    }
-
-    @Override
-    public void onViewAttachedToWindow(ViewHolder holder) {
-        super.onViewAttachedToWindow(holder);
-    }
-
-    @Override
-    public void onViewDetachedFromWindow(ViewHolder holder) {
-        super.onViewDetachedFromWindow(holder);
-    }
-
-    @Override
-    public void onDetachedFromRecyclerView(RecyclerView recyclerView) {
-        super.onDetachedFromRecyclerView(recyclerView);
     }
 
     public void setVideoList(@Nullable List<Video> trackList) {

--- a/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/VideoListAdapter.java
+++ b/Player/AudioOnlySampleApp-java/src/main/java/com/brightcove/player/samples/audioonly/java/VideoListAdapter.java
@@ -74,7 +74,7 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
                     brightcoveVideoView.setCurrentIndex(holder.getAbsoluteAdapterPosition());
                     brightcoveVideoView.start();
                 } catch (Exception e) {
-                    Log.v(TAG, "Error loading media:" + video.getId());
+                    Log.e(TAG, "Error loading media:" + video.getId(), e);
                 }
             });
         }

--- a/Player/AudioOnlySampleApp-java/src/main/res/values/strings.xml
+++ b/Player/AudioOnlySampleApp-java/src/main/res/values/strings.xml
@@ -3,10 +3,10 @@
     <string name="app_name">AudioOnly Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">4800266849001</string>
+    <string name="sdk_demo_account">4800266849001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM3n0ImwKortQqSZCgJMcyVbb8lJVwt0z16UD0a_h8MpEYcHyKbM8CGOPxBRp0nfSVdfokXBrUu3Sso7Nujv3dnLo0JxC_lNXCl88O7NJ0PR0z2AprnJ_Lwnq7nTcy1GBUrQPr5e</string>
+    <string name="sdk_demo_policy">BCpkADawqM3n0ImwKortQqSZCgJMcyVbb8lJVwt0z16UD0a_h8MpEYcHyKbM8CGOPxBRp0nfSVdfokXBrUu3Sso7Nujv3dnLo0JxC_lNXCl88O7NJ0PR0z2AprnJ_Lwnq7nTcy1GBUrQPr5e</string>
 
     <!-- A sample Brightcove Track Playlist Reference -->
     <string name="trackPlaylistReference">royalty_free_mp3</string>

--- a/Player/AudioOnlySampleApp-kotlin/README.md
+++ b/Player/AudioOnlySampleApp-kotlin/README.md
@@ -9,6 +9,6 @@ Plays audio-only assets with a media-style background playback notification, so 
 
 | File | Responsibility |
 |---|---|
-| `AudioOnlyActivity.kt` | Loads the playlist via `Catalog`, wires the shuffle and repeat controls, attaches the background playback notification, and renders the track list. |
+| `MainActivity.kt` | Loads the playlist via `Catalog`, wires the shuffle and repeat controls, attaches the background playback notification, and renders the track list. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/AudioOnlySampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".AudioOnlyActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/AudioOnlySampleApp-kotlin/src/main/java/com/brightcove/player/samples/audioonly/kotlin/MainActivity.kt
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/java/com/brightcove/player/samples/audioonly/kotlin/MainActivity.kt
@@ -37,14 +37,17 @@ import com.brightcove.player.samples.audioonly.kotlin.databinding.ActivityAudioO
 import com.brightcove.player.model.Video as Media
 
 
-class AudioOnlyActivity : BrightcovePlayerActivity() {
+/**
+ * Demonstrates audio-only playback: a Brightcove playlist of audio tracks played with a
+ * media-style background playback notification, plus shuffle and repeat controls.
+ */
+class MainActivity : BrightcovePlayerActivity() {
 
     private lateinit var binding: ViewBinding
 
     private val catalog: Catalog by lazy {
-        Catalog.Builder(player.eventEmitter, getString(R.string.account_id))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.policy_id))
+        Catalog.Builder(player.eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
     }
 
@@ -135,7 +138,7 @@ class AudioOnlyActivity : BrightcovePlayerActivity() {
 
     private fun setPlaylist(playlist: Playlist) = binding.run {
         player.addAll(playlist.videos)
-        list.layoutManager = LinearLayoutManager(this@AudioOnlyActivity)
+        list.layoutManager = LinearLayoutManager(this@MainActivity)
         list.adapter = PlaylistAdapter(playlist.videos, ::onClick)
         fadeOut(loading); fadeIn(list, player)
     }

--- a/Player/AudioOnlySampleApp-kotlin/src/main/res/layout/activity_audio_only.xml
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/res/layout/activity_audio_only.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".AudioOnlyActivity">
+    tools:context=".MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"

--- a/Player/AudioOnlySampleApp-kotlin/src/main/res/layout/item_audio.xml
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/res/layout/item_audio.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
     android:clickable="true"
-    tools:context=".AudioOnlyActivity">
+    tools:context=".MainActivity">
 
     <ImageView
         android:id="@+id/album_art"

--- a/Player/AudioOnlySampleApp-kotlin/src/main/res/menu/menu_main.xml
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.brightcove.player.samples.audioonly.kotlin.AudioOnlyActivity">
+    tools:context="com.brightcove.player.samples.audioonly.kotlin.MainActivity">
     <item
         android:id="@+id/action_shuffle"
         android:orderInCategory="100"

--- a/Player/AudioOnlySampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/AudioOnlySampleApp-kotlin/src/main/res/values/strings.xml
@@ -4,13 +4,9 @@
     <string name="action_shuffle">Shuffle</string>
     <string name="action_repeat">Repeat</string>
 
-    <string name="account_id" translatable="false">1752604059001</string>
-    <string name="policy_id" translatable="false">BCpkADawqM3kB3bqHvE8_X0h_lrMiTXaQe_ZUqI3RAYrtJBxzBTITabUcArd4uRVOo1usGJOw65qRqPflytxOyMTxfbD4uQvqpa5sTJxHStKgDdCOD7FySh5wXhVU4wHKad_4OHQ4Fcsd_HD</string>
+    <string name="sdk_demo_account" translatable="false">1752604059001</string>
+    <string name="sdk_demo_policy" translatable="false">BCpkADawqM3kB3bqHvE8_X0h_lrMiTXaQe_ZUqI3RAYrtJBxzBTITabUcArd4uRVOo1usGJOw65qRqPflytxOyMTxfbD4uQvqpa5sTJxHStKgDdCOD7FySh5wXhVU4wHKad_4OHQ4Fcsd_HD</string>
     <string name="reference_id" translatable="false">audio_only_sample</string>
-
-<!--    <string name="account_id" translatable="false">4800266849001</string>-->
-<!--    <string name="policy_id" translatable="false">BCpkADawqM3n0ImwKortQqSZCgJMcyVbb8lJVwt0z16UD0a_h8MpEYcHyKbM8CGOPxBRp0nfSVdfokXBrUu3Sso7Nujv3dnLo0JxC_lNXCl88O7NJ0PR0z2AprnJ_Lwnq7nTcy1GBUrQPr5e</string>-->
-<!--    <string name="reference_id" translatable="false">mixed_aod_vod_vod_first</string>-->
 
     <string name="cd_album_art">Album Art</string>
 </resources>

--- a/Player/BasicSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/BasicSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.basic.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/BasicSampleApp-java/src/main/java/com/brightcove/player/samples/basic/java/MainActivity.java
+++ b/Player/BasicSampleApp-java/src/main/java/com/brightcove/player/samples/basic/java/MainActivity.java
@@ -3,31 +3,33 @@ package com.brightcove.player.samples.basic.java;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
+
+import java.util.List;
 
 /**
  * This app illustrates how to use the ExoPlayer with the Brightcove
  * Native Player SDK for Android.
- *
- * @author Billy Hnath (bhnath@brightcove.com)
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
@@ -36,11 +38,10 @@ public class MainActivity extends BrightcovePlayer {
         String account = getString(R.string.sdk_demo_account);
 
         Catalog catalog = new Catalog.Builder(eventEmitter, account)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -49,6 +50,11 @@ public class MainActivity extends BrightcovePlayer {
                 Log.v(TAG, "onVideo: video = " + video);
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/Player/BasicSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/BasicSampleApp-java/src/main/res/values/strings.xml
@@ -10,6 +10,6 @@
     <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/Player/BasicSampleApp-kotlin/README.md
+++ b/Player/BasicSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ The minimal player — fetches a video from the Catalog and plays it in a `Brigh
 
 | File | Responsibility |
 |---|---|
-| `BasicSampleActivity.kt` | Fetches a video from the Catalog and starts playback. |
+| `MainActivity.kt` | Fetches a video from the Catalog and starts playback. |
 | `res/layout/activity_basic_sample_app.xml` | Screen layout hosting the `BrightcoveExoPlayerVideoView`. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/BasicSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/BasicSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".BasicSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/Player/BasicSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basic/kotlin/MainActivity.kt
+++ b/Player/BasicSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basic/kotlin/MainActivity.kt
@@ -4,12 +4,17 @@ import android.os.Bundle
 import android.util.Log
 import com.brightcove.player.samples.basic.kotlin.databinding.ActivityBasicSampleAppBinding
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayer
 
-class BasicSampleActivity : BrightcovePlayer() {
+/**
+ * This app illustrates how to use the ExoPlayer with the Brightcove
+ * Native Player SDK for Android.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityBasicSampleAppBinding
 
@@ -23,18 +28,16 @@ class BasicSampleActivity : BrightcovePlayer() {
         brightcoveVideoView = binding.brightcoveVideoView
         super.onCreate(savedInstanceState)
 
-
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
         // Brightcove Edge service, given a video id, an account id and a policy key.
         val eventEmitter: EventEmitter = brightcoveVideoView.eventEmitter
         val account = getString(R.string.sdk_demo_account)
 
         val catalog = Catalog.Builder(eventEmitter, account)
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             // Add the video found to the queue with add().
             // Start playback of the video with start().
             override fun onVideo(video: Video) {
@@ -42,7 +45,14 @@ class BasicSampleActivity : BrightcovePlayer() {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
-        })
 
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
+        })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/BasicSampleApp-kotlin/src/main/res/layout/activity_basic_sample_app.xml
+++ b/Player/BasicSampleApp-kotlin/src/main/res/layout/activity_basic_sample_app.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".BasicSampleActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/BasicSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/BasicSampleApp-kotlin/src/main/res/values/strings.xml
@@ -10,6 +10,6 @@
     <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/Player/BumperSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/BumperSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.bumper.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/BumperSampleApp-java/src/main/java/com/brightcove/player/samples/bumper/java/MainActivity.java
+++ b/Player/BumperSampleApp-java/src/main/java/com/brightcove/player/samples/bumper/java/MainActivity.java
@@ -5,11 +5,13 @@ import android.util.Log;
 
 import com.brightcove.player.bumper.BumperComponent;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -18,16 +20,18 @@ import java.util.Map;
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
     private BumperComponent bumperComponent;
 
-    private Boolean useSetBumperID = true;
+    // Demo switch: when true the bumper id is set manually; flip to false to read it from the
+    // video's "bumper_id" custom field instead.
+    private boolean useSetBumperID = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
@@ -38,26 +42,25 @@ public class MainActivity extends BrightcovePlayer {
         EventEmitter eventEmitter = brightcoveVideoView.getEventEmitter();
 
         Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        //Building the instance of the bumper component, providing the existing videoView and catalog.
+        // Build the bumper component with the existing videoView and catalog.
         bumperComponent = new BumperComponent.Builder(brightcoveVideoView, catalog).build();
-        //Initializing the bumper.
+        // Initialize the bumper.
         bumperComponent.init();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
             // Add the video found to the queue with add().
             @Override
             public void onVideo(Video video) {
                 // Showcasing both options to set the bumper id manually or obtaining it from the
                 // video object properties
                 if (useSetBumperID) {
-                    //Manually Setting our own bumper ID
+                    // Manually set our own bumper id.
                     bumperComponent.setVideoBumperID(getString(R.string.sdk_demo_bumper_videoId));
                 } else {
-                    //Obtaining the bumper id from the video custom fields
+                    // Obtain the bumper id from the video's custom fields.
                     Map<String, Object> customFields =
                             (Map<String, Object>) video.getProperties().get(Video.Fields.CUSTOM_FIELDS);
                     if ((customFields != null && !customFields.isEmpty()) &&
@@ -66,10 +69,13 @@ public class MainActivity extends BrightcovePlayer {
                     }
                 }
                 Log.v(TAG, "onVideo: video = " + video);
-                //Adding the video
                 brightcoveVideoView.add(video);
-                //Autostart Playback
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/Player/BumperSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/BumperSampleApp-java/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538244001</string>
+    <string name="sdk_demo_video_id">5421538244001</string>
 
     <!-- A sample Brightcove Bumper Video ID -->
     <string name="sdk_demo_bumper_videoId">6359004103112</string>

--- a/Player/BumperSampleApp-kotlin/README.md
+++ b/Player/BumperSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Plays a short bumper video ahead of the main content.
 
 | File | Responsibility |
 |---|---|
-| `BumperSampleActivity.kt` | Configures the `BumperComponent` and plays a bumper before the main video. |
+| `MainActivity.kt` | Configures the `BumperComponent` and plays a bumper before the main video. |
 | `res/layout/activity_bumper_sample_app.xml` | Screen layout hosting the `BrightcoveExoPlayerVideoView`. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/BumperSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/BumperSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:theme="@style/Theme.BasicSampleApp"
         tools:targetApi="31">
         <activity
-            android:name=".BumperSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/Player/BumperSampleApp-kotlin/src/main/java/com/brightcove/player/samples/bumper/kotlin/MainActivity.kt
+++ b/Player/BumperSampleApp-kotlin/src/main/java/com/brightcove/player/samples/bumper/kotlin/MainActivity.kt
@@ -5,17 +5,23 @@ import android.util.Log
 import com.brightcove.player.samples.bumper.kotlin.databinding.ActivityBumperSampleAppBinding
 import com.brightcove.player.bumper.BumperComponent
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
-import com.brightcove.player.event.EventEmitter
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayer
 
-class BumperSampleActivity : BrightcovePlayer() {
+/**
+ * This app illustrates how to use the ExoPlayer and the BumperComponent with the Brightcove
+ * Native Player SDK for Android.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityBumperSampleAppBinding
 
     private var bumperComponent: BumperComponent? = null
 
+    // Demo switch: when true the bumper id is set manually; flip to false to read it from the
+    // video's "bumper_id" custom field instead.
     private val useSetBumperID = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,34 +34,30 @@ class BumperSampleActivity : BrightcovePlayer() {
         brightcoveVideoView = binding.brightcoveVideoView
         super.onCreate(savedInstanceState)
 
-
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
         // Brightcove Edge service, given a video id, an account id and a policy key.
-        val eventEmitter: EventEmitter = brightcoveVideoView.eventEmitter
+        val eventEmitter = brightcoveVideoView.eventEmitter
         val account = getString(R.string.sdk_demo_account)
 
         val catalog = Catalog.Builder(eventEmitter, account)
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-
-        //Building the instance of the bumper component, providing the existing videoView and catalog.
+        // Build the bumper component with the existing videoView and catalog.
         bumperComponent = BumperComponent.Builder(brightcoveVideoView, catalog).build()
-
-        //Initializing the bumper.
+        // Initialize the bumper.
         bumperComponent?.init()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             // Add the video found to the queue with add().
             override fun onVideo(video: Video) {
                 // Showcasing both options to set the bumper id manually or obtaining it from the
                 // video object properties
                 if (useSetBumperID) {
-                    //Manually Setting our own bumper ID
+                    // Manually set our own bumper id.
                     bumperComponent?.setVideoBumperID(getString(R.string.sdk_demo_bumper_videoId))
                 } else {
-                    //Obtaining the bumper id from the video custom fields
+                    // Obtain the bumper id from the video's custom fields.
                     val customFields =
                         video.properties[Video.Fields.CUSTOM_FIELDS] as Map<*, *>?
                     if ((customFields != null && customFields.isNotEmpty()) &&
@@ -65,12 +67,17 @@ class BumperSampleActivity : BrightcovePlayer() {
                     }
                 }
                 Log.v(TAG, "onVideo: video = $video")
-                //Adding the video
                 brightcoveVideoView.add(video)
-                //Autostart Playback
                 brightcoveVideoView.start()
             }
-        })
 
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
+        })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/BumperSampleApp-kotlin/src/main/res/layout/activity_bumper_sample_app.xml
+++ b/Player/BumperSampleApp-kotlin/src/main/res/layout/activity_bumper_sample_app.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".BumperSampleActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/BumperSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/BumperSampleApp-kotlin/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538244001</string>
+    <string name="sdk_demo_video_id">5421538244001</string>
 
     <!-- A sample Brightcove Bumper Video ID -->
     <string name="sdk_demo_bumper_videoId">6359004103112</string>

--- a/Player/LiveSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/LiveSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.live.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/LiveSampleApp-java/src/main/java/com/brightcove/player/samples/live/java/MainActivity.java
+++ b/Player/LiveSampleApp-java/src/main/java/com/brightcove/player/samples/live/java/MainActivity.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 
 import com.brightcove.player.model.DeliveryType;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
 /**
@@ -13,16 +12,14 @@ import com.brightcove.player.view.BrightcovePlayer;
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         // A Live/DVR stream is not bundled with this sample: live streams are ephemeral, so

--- a/Player/LiveSampleApp-kotlin/README.md
+++ b/Player/LiveSampleApp-kotlin/README.md
@@ -6,10 +6,10 @@ Plays HLS Live and Live DVR content with the live control layout, which shows a 
 
 | File | Responsibility |
 |---|---|
-| `LiveSampleActivity.kt` | Builds an HLS Live video from placeholder values and starts playback. |
+| `MainActivity.kt` | Builds an HLS Live video from placeholder values and starts playback. |
 
 ## Supplying a stream
 
-This sample does not ship with a playable stream: live streams are ephemeral, so Brightcove cannot bundle a permanent one. In `LiveSampleActivity.kt`, replace the `YOUR_LIVE_HLS_STREAM` placeholder with your own Video Cloud Live/DVR HLS stream URL and the `YOUR_VIDEOCLOUD_PUBLISHER_ID` placeholder with your publisher id. Until you do, the app builds and launches but has nothing to play.
+This sample does not ship with a playable stream: live streams are ephemeral, so Brightcove cannot bundle a permanent one. In `MainActivity.kt`, replace the `YOUR_LIVE_HLS_STREAM` placeholder with your own Video Cloud Live/DVR HLS stream URL and the `YOUR_VIDEOCLOUD_PUBLISHER_ID` placeholder with your publisher id. Until you do, the app builds and launches but has nothing to play.
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/LiveSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/LiveSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Base.Theme.LiveSampleApp">
         <activity
-            android:name=".LiveSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/Player/LiveSampleApp-kotlin/src/main/java/com/brightcove/player/samples/live/kotlin/MainActivity.kt
+++ b/Player/LiveSampleApp-kotlin/src/main/java/com/brightcove/player/samples/live/kotlin/MainActivity.kt
@@ -6,14 +6,18 @@ import com.brightcove.player.model.DeliveryType
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcovePlayer
 
-class LiveSampleActivity : BrightcovePlayer() {
+/**
+ * This app illustrates how to use the Brightcove Native Player SDK
+ * for Android to play an HLS Live stream.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityLiveSampleBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         binding = ActivityLiveSampleBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/Player/LiveSampleApp-kotlin/src/main/res/layout/activity_live_sample.xml
+++ b/Player/LiveSampleApp-kotlin/src/main/res/layout/activity_live_sample.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical"
-    tools:context=".LiveSampleActivity" >
+    tools:context=".MainActivity" >
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/MainActivity.java
+++ b/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/MainActivity.java
@@ -7,32 +7,42 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.pictureinpicture.PictureInPictureManager;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
 
+import java.util.List;
+
+/**
+ * Demonstrates Android Picture-in-Picture mode: playback continues in a floating
+ * window when the user leaves the app, with PiP behavior configurable via a
+ * companion settings screen.
+ */
 public class MainActivity extends BrightcovePlayer {
+
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
         // Brightcove Edge service, given a video id, an account id and a policy key.
         EventEmitter eventEmitter = brightcoveVideoView.getEventEmitter();
 
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.policy))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -41,6 +51,11 @@ public class MainActivity extends BrightcovePlayer {
                 Log.v(TAG, "onVideo: video = " + video);
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsActivity.java
+++ b/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsActivity.java
@@ -8,6 +8,9 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.view.MenuItem;
 
+/**
+ * Hosts the Picture-in-Picture preferences screen for adjusting PiP behavior.
+ */
 public class SettingsActivity extends PreferenceActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsActivity.java
+++ b/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsActivity.java
@@ -1,7 +1,6 @@
 package com.brightcove.player.samples.pictureinpicture.java;
 
 import android.annotation.TargetApi;
-import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
@@ -31,7 +30,7 @@ public class SettingsActivity extends PreferenceActivity {
         public boolean onOptionsItemSelected(MenuItem item) {
             int id = item.getItemId();
             if (id == android.R.id.home) {
-                startActivity(new Intent(getActivity(), SettingsActivity.class));
+                getActivity().finish();
                 return true;
             }
             return super.onOptionsItemSelected(item);

--- a/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsModel.java
+++ b/Player/PictureInPictureSampleApp-java/src/main/java/com/brightcove/player/samples/pictureinpicture/java/SettingsModel.java
@@ -6,9 +6,8 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
+import android.util.Log;
 import android.util.Rational;
-
-import com.brightcove.player.logging.Log;
 
 public class SettingsModel {
 
@@ -69,7 +68,7 @@ public class SettingsModel {
                 String numbers[] = rationalString.split(":");
                 numerator = Integer.parseInt(numbers[0]);
                 denominator = Integer.parseInt(numbers[1]);
-                Log.w("PIP", String.format("RATIONAL N=%s, D=%s", numerator, denominator));
+                Log.w(TAG, String.format("RATIONAL N=%s, D=%s", numerator, denominator));
                 rational = new Rational(numerator, denominator);
             }
         } catch (NumberFormatException e) {

--- a/Player/PictureInPictureSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/PictureInPictureSampleApp-java/src/main/res/values/strings.xml
@@ -2,13 +2,13 @@
     <string name="app_name">PictureInPictureSampleApp</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5733185764001</string>
+    <string name="sdk_demo_video_id">5733185764001</string>
 
     <string name="enter_picture_in_picture">ENTER PICTURE IN PICTURE MODE</string>
     <string name="configure_picture_in_picture">CONFIGURE PICTURE IN PICTURE</string>

--- a/Player/PictureInPictureSampleApp-kotlin/README.md
+++ b/Player/PictureInPictureSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Enters Android Picture-in-Picture mode so playback continues in a small floating
 
 | File | Responsibility |
 |---|---|
-| `PictureInPictureSampleActivity.kt` | Fetches a video and applies saved PiP settings on resume. |
+| `MainActivity.kt` | Fetches a video and applies saved PiP settings on resume. |
 | `SettingsActivity.kt` | Hosts the preference screen for editing PiP options. |
 | `SettingsModel.kt` | Reads PiP preferences (captions, scale factor, aspect ratio) from shared preferences. |
 

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
             android:name=".SettingsActivity"
             android:exported="false" />
         <activity
-            android:name=".PictureInPictureSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
             android:exported="true"
             android:launchMode="singleTask"

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/MainActivity.kt
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/MainActivity.kt
@@ -6,13 +6,19 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
 import com.brightcove.player.pictureinpicture.PictureInPictureManager
 import com.brightcove.player.view.BrightcovePlayer
 import com.brightcove.player.samples.pictureinpicture.kotlin.databinding.ActivityPictureInPictureSampleBinding
 
-class PictureInPictureSampleActivity : BrightcovePlayer() {
+/**
+ * Demonstrates Android Picture-in-Picture mode: playback continues in a floating
+ * window when the user leaves the app, with PiP behavior configurable via a
+ * companion settings screen.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityPictureInPictureSampleBinding
 
@@ -25,18 +31,21 @@ class PictureInPictureSampleActivity : BrightcovePlayer() {
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
         // Brightcove Edge service, given a video id, an account id and a policy key.
         val eventEmitter = brightcoveVideoView.eventEmitter
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.policy))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             // Add the video found to the queue with add().
             // Start playback of the video with start().
             override fun onVideo(video: Video) {
                 Log.v(TAG, "onVideo: video = $video")
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
 
@@ -68,5 +77,9 @@ class PictureInPictureSampleActivity : BrightcovePlayer() {
                 Toast.LENGTH_LONG
             ).show()
         }
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/SettingsActivity.kt
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/SettingsActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceFragmentCompat
 
+/**
+ * Hosts the Picture-in-Picture preferences screen for adjusting PiP behavior.
+ */
 class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/SettingsModel.kt
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/java/com/brightcove/player/samples/pictureinpicture/kotlin/SettingsModel.kt
@@ -4,9 +4,9 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
+import android.util.Log
 import android.util.Rational
 import androidx.preference.PreferenceManager
-import com.brightcove.player.logging.Log
 
 class SettingsModel(context: Context) {
 
@@ -29,7 +29,7 @@ class SettingsModel(context: Context) {
         var scaleFactor = 0.5f
         val scaleFactorString = preferences.getString(PIP_CC_SCALE_FACTOR, scaleFactor.toString())
         try {
-            scaleFactor = scaleFactorString!!.toFloat()
+            scaleFactor = scaleFactorString?.toFloat() ?: scaleFactor
         } catch (e: NumberFormatException) {
             Log.e(TAG, "Error retrieving bitrate configuration.", e)
         }
@@ -47,7 +47,7 @@ class SettingsModel(context: Context) {
                 val numbers = rationalString.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
                 numerator = numbers[0].toInt()
                 denominator = numbers[1].toInt()
-                Log.w("PIP", String.format("RATIONAL N=%s, D=%s", numerator, denominator))
+                Log.w(TAG, "RATIONAL N=$numerator, D=$denominator")
                 rational = Rational(numerator, denominator)
             }
         } catch (e: NumberFormatException) {
@@ -77,6 +77,6 @@ class SettingsModel(context: Context) {
          */
         const val PIP_ASPECT_RATIO = "picture_in_picture_aspect_ratio"
 
-        private val TAG: String = SettingsModel::class.java.simpleName
+        private const val TAG = "SettingsModel"
     }
 }

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/res/layout/activity_picture_in_picture_sample.xml
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/res/layout/activity_picture_in_picture_sample.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".PictureInPictureSampleActivity"
+    tools:context=".MainActivity"
     android:orientation="vertical">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView

--- a/Player/PictureInPictureSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/PictureInPictureSampleApp-kotlin/src/main/res/values/strings.xml
@@ -2,13 +2,13 @@
     <string name="app_name">PictureInPictureSampleApp</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy" tools:ignore="Typos">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy" tools:ignore="Typos">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5733185764001</string>
+    <string name="sdk_demo_video_id">5733185764001</string>
 
     <string name="enter_picture_in_picture">ENTER PICTURE IN PICTURE MODE</string>
     <string name="configure_picture_in_picture">CONFIGURE PICTURE IN PICTURE</string>

--- a/Player/TextureViewSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/TextureViewSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.textureview.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/TextureViewSampleApp-java/src/main/java/com/brightcove/player/samples/textureview/java/MainActivity.java
+++ b/Player/TextureViewSampleApp-java/src/main/java/com/brightcove/player/samples/textureview/java/MainActivity.java
@@ -3,12 +3,16 @@ package com.brightcove.player.samples.textureview.java;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
-import com.brightcove.player.view.BrightcoveExoPlayerTextureVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
+
+import java.util.List;
 
 /**
  * This app illustrates how to use the ExoPlayer and a TextureView
@@ -16,16 +20,16 @@ import com.brightcove.player.view.BrightcovePlayer;
  */
 public class MainActivity extends BrightcovePlayer {
 
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerTextureVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         super.onCreate(savedInstanceState);
 
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
@@ -34,11 +38,10 @@ public class MainActivity extends BrightcovePlayer {
         String account = getString(R.string.sdk_demo_account);
 
         Catalog catalog = new Catalog.Builder(eventEmitter, account)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -47,6 +50,11 @@ public class MainActivity extends BrightcovePlayer {
                 Log.v(TAG, "onVideo: video = " + video);
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/Player/TextureViewSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/TextureViewSampleApp-java/src/main/res/values/strings.xml
@@ -10,6 +10,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/Player/TextureViewSampleApp-kotlin/README.md
+++ b/Player/TextureViewSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Renders playback into a `TextureView` instead of the default `SurfaceView`, via 
 
 | File | Responsibility |
 |---|---|
-| `TextureViewSampleActivity.kt` | Fetches a video and plays it in the `TextureView`-backed player. |
+| `MainActivity.kt` | Fetches a video and plays it in the `TextureView`-backed player. |
 | `res/layout/activity_texture_view_sample.xml` | Screen layout hosting the `BrightcoveExoPlayerTextureVideoView`. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/TextureViewSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/TextureViewSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Base.Theme.TextureViewSample"
         android:usesCleartextTraffic="true">
         <activity
-            android:name=".TextureViewSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/Player/TextureViewSampleApp-kotlin/src/main/java/com/brightcove/player/samples/textureview/kotlin/MainActivity.kt
+++ b/Player/TextureViewSampleApp-kotlin/src/main/java/com/brightcove/player/samples/textureview/kotlin/MainActivity.kt
@@ -2,26 +2,29 @@ package com.brightcove.player.samples.textureview.kotlin
 
 import android.os.Bundle
 import android.util.Log
-import android.view.View
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerTextureVideoView
 import com.brightcove.player.view.BrightcovePlayer
 import com.brightcove.player.samples.textureview.kotlin.databinding.ActivityTextureViewSampleBinding
 
-class TextureViewSampleActivity : BrightcovePlayer() {
+/**
+ * This app illustrates how to use the ExoPlayer and a TextureView
+ * with the Brightcove Native Player SDK for Android.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityTextureViewSampleBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         binding = ActivityTextureViewSampleBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        brightcoveVideoView = findViewById<View>(R.id.brightcove_video_view) as BrightcoveExoPlayerTextureVideoView
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         // Get the event emitter from the SDK and create a catalog request to fetch a video from the
@@ -29,11 +32,10 @@ class TextureViewSampleActivity : BrightcovePlayer() {
         val eventEmitter = brightcoveVideoView.eventEmitter
         val account = getString(R.string.sdk_demo_account)
         val catalog = Catalog.Builder(eventEmitter, account)
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             // Add the video found to the queue with add().
             // Start playback of the video with start().
             override fun onVideo(video: Video) {
@@ -41,10 +43,14 @@ class TextureViewSampleActivity : BrightcovePlayer() {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
     }
 
     companion object {
-        private val TAG = TextureViewSampleActivity::class.java.simpleName
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/TextureViewSampleApp-kotlin/src/main/res/layout/activity_texture_view_sample.xml
+++ b/Player/TextureViewSampleApp-kotlin/src/main/res/layout/activity_texture_view_sample.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical"
-    tools:context=".TextureViewSampleActivity" >
+    tools:context=".MainActivity" >
 
     <com.brightcove.player.view.BrightcoveExoPlayerTextureVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/TextureViewSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/TextureViewSampleApp-kotlin/src/main/res/values/strings.xml
@@ -8,5 +8,5 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 </resources>

--- a/Player/ThumbnailScrubberSampleApp-java/src/main/AndroidManifest.xml
+++ b/Player/ThumbnailScrubberSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.thumbnailscrubber.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/Player/ThumbnailScrubberSampleApp-java/src/main/java/com/brightcove/player/samples/thumbnailscrubber/java/MainActivity.java
+++ b/Player/ThumbnailScrubberSampleApp-java/src/main/java/com/brightcove/player/samples/thumbnailscrubber/java/MainActivity.java
@@ -3,14 +3,18 @@ package com.brightcove.player.samples.thumbnailscrubber.java;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.mediacontroller.ThumbnailComponent;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BaseVideoView;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
+
+import java.util.List;
 
 /**
  * This app demonstrates the Brightcove Thumbnail Plugin and Thumbnail Scrubbing.
@@ -25,7 +29,7 @@ public class MainActivity extends BrightcovePlayer {
         // This allows for some stock video player lifecycle management.
         // Establish the VideoView object and use its event emitter to get important notifications and to control logging.
         setContentView(R.layout.activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         configureThumbnailScrubber(brightcoveVideoView);
 
         super.onCreate(savedInstanceState);
@@ -35,12 +39,12 @@ public class MainActivity extends BrightcovePlayer {
 
         // Create a Catalog object to fetch a video from the Brightcove Edge service.
         // Apply the Edge API override here to point the Catalog to Edge API v2
-        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.account))
-                            .setPolicy(getString(R.string.policy))
+        Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+                            .setPolicy(getString(R.string.sdk_demo_policy))
                             .build();
 
         // Retrieve the video, given a video id, an account id and a policy key
-        catalog.findVideoByID(getString(R.string.videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -49,6 +53,11 @@ public class MainActivity extends BrightcovePlayer {
                 Log.v(TAG, "onVideo: video = " + video);
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/Player/ThumbnailScrubberSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/ThumbnailScrubberSampleApp-java/src/main/res/values/strings.xml
@@ -5,12 +5,12 @@
     <string name="app_name">Thumbnail Scrubber Sample App</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/Player/ThumbnailScrubberSampleApp-kotlin/README.md
+++ b/Player/ThumbnailScrubberSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Shows thumbnail previews while scrubbing the seek bar, using the Brightcove thum
 
 | File | Responsibility |
 |---|---|
-| `ThumbnailScrubbingMainActivity.kt` | Attaches the `ThumbnailComponent`, then fetches and plays the video. |
+| `MainActivity.kt` | Attaches the `ThumbnailComponent`, then fetches and plays the video. |
 | `res/layout/activity_thumbnail_scrubbing_main.xml` | Screen layout hosting the `BrightcoveExoPlayerVideoView`. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/ThumbnailScrubberSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/ThumbnailScrubberSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Androidplayersamples" >
         <activity
-            android:name=".ThumbnailScrubbingMainActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
             android:theme="@style/Theme.Androidplayersamples" >

--- a/Player/ThumbnailScrubberSampleApp-kotlin/src/main/java/com/brightcove/player/samples/thumbnailscrubber/kotlin/MainActivity.kt
+++ b/Player/ThumbnailScrubberSampleApp-kotlin/src/main/java/com/brightcove/player/samples/thumbnailscrubber/kotlin/MainActivity.kt
@@ -3,6 +3,7 @@ package com.brightcove.player.samples.thumbnailscrubber.kotlin
 import android.os.Bundle
 import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.mediacontroller.ThumbnailComponent
 import com.brightcove.player.model.Video
@@ -10,7 +11,10 @@ import com.brightcove.player.view.BaseVideoView
 import com.brightcove.player.view.BrightcovePlayer
 import com.brightcove.player.samples.thumbnailscrubber.kotlin.databinding.ActivityThumbnailScrubbingMainBinding
 
-class ThumbnailScrubbingMainActivity : BrightcovePlayer() {
+/**
+ * This app demonstrates the Brightcove Thumbnail Plugin and Thumbnail Scrubbing.
+ */
+class MainActivity : BrightcovePlayer() {
 
     private lateinit var binding: ActivityThumbnailScrubbingMainBinding
 
@@ -31,19 +35,23 @@ class ThumbnailScrubbingMainActivity : BrightcovePlayer() {
         // Brightcove Edge service, given a video id, an account id and a policy key.
         val eventEmitter = brightcoveVideoView.eventEmitter
 
-        val catalog = Catalog.Builder(eventEmitter, getString(R.string.account))
-            .setPolicy(getString(R.string.policy))
+        val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
 
         // Retrieve the video, given a video id, an account id and a policy key
-        catalog.findVideoByID(getString(R.string.videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             // Add the video found to the queue with add().
             // Start playback of the video with start().
             override fun onVideo(video: Video) {
                 Log.v(TAG, "onVideo: video = $video")
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
     }
@@ -56,5 +64,9 @@ class ThumbnailScrubbingMainActivity : BrightcovePlayer() {
         Log.v(TAG,"Thumbnail Scrubbing is enabled, setting up the PreviewThumbnailController")
         val thumbnailComponent = ThumbnailComponent(brightcoveVideoView)
         thumbnailComponent.setupPreviewThumbnailController()
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/Player/ThumbnailScrubberSampleApp-kotlin/src/main/res/layout/activity_thumbnail_scrubbing_main.xml
+++ b/Player/ThumbnailScrubberSampleApp-kotlin/src/main/res/layout/activity_thumbnail_scrubbing_main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".ThumbnailScrubbingMainActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/Player/ThumbnailScrubberSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/ThumbnailScrubberSampleApp-kotlin/src/main/res/values/strings.xml
@@ -2,12 +2,12 @@
     <string name="app_name">ThumbnailScrubberSampleApp</string>
 
     <!-- A sample Brightcove Edge Account ID -->
-    <string name="account">5420904993001</string>
+    <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/Player/VideoListSampleApp-java/README.md
+++ b/Player/VideoListSampleApp-java/README.md
@@ -7,6 +7,6 @@ Shows multiple independent Brightcove player instances in a scrolling `RecyclerV
 | File | Responsibility |
 |---|---|
 | `MainActivity.java` | Fetches a playlist via `Catalog` and populates the RecyclerView. |
-| `AdapterView.java` | RecyclerView adapter; builds a player per row and manages its playback lifecycle. |
+| `VideoListAdapter.java` | RecyclerView adapter; builds a player per row and manages its playback lifecycle. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/MainActivity.java
+++ b/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/MainActivity.java
@@ -11,27 +11,30 @@ import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventEmitterImpl;
 import com.brightcove.player.model.Playlist;
 
+/**
+ * Fetches a Brightcove playlist and displays each video in a scrolling
+ * RecyclerView, with a dedicated player for every row.
+ */
 public class MainActivity extends AppCompatActivity {
 
     private Catalog catalog;
     private RecyclerView videoListView;
-    private AdapterView adapterView;
+    private VideoListAdapter adapterView;
 
     EventEmitter eventEmitter = new EventEmitterImpl();
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
-        videoListView = (RecyclerView) findViewById(R.id.video_list_view);
+        videoListView = findViewById(R.id.video_list_view);
 
-        adapterView = new AdapterView();
+        adapterView = new VideoListAdapter();
         videoListView.setAdapter(adapterView);
 
         catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.sdk_demo_policy_key))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         catalog.findPlaylistByReferenceID(getString(R.string.sdk_demo_playlist_reference), new PlaylistListener() {

--- a/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/VideoListAdapter.java
+++ b/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/VideoListAdapter.java
@@ -2,7 +2,6 @@ package com.brightcove.player.samples.videolist.java;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.util.SparseArray;
@@ -76,7 +75,7 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
         }
     }
 
-    public void setVideoList(@Nullable List<Video> videoList) {
+    public void setVideoList(@NonNull List<Video> videoList) {
         this.videoList.clear();
         this.videoList.addAll(videoList);
         notifyDataSetChanged();

--- a/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/VideoListAdapter.java
+++ b/Player/VideoListSampleApp-java/src/main/java/com/brightcove/player/samples/videolist/java/VideoListAdapter.java
@@ -12,9 +12,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
-import com.brightcove.player.event.EventListener;
 import com.brightcove.player.event.EventType;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
@@ -23,7 +21,7 @@ import com.brightcove.player.view.BrightcoveVideoView;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
+public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.ViewHolder> {
 
     private final List<Video> videoList = new ArrayList<>();
     private final SparseArray<Long> playheadPositions = new SparseArray<>(); // this is used to keep track of the playback position for each video; remove it and its associated logic to play from the start always
@@ -36,7 +34,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        //Get Video information
         Video video = videoList == null ? null : videoList.get(position);
         if (video != null) {
             holder.videoTitleText.setText(video.getStringProperty(Video.Fields.NAME));
@@ -47,11 +44,6 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
     @Override
     public int getItemCount() {
         return videoList.size();
-    }
-
-    @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
-        super.onAttachedToRecyclerView(recyclerView);
     }
 
     @Override
@@ -101,18 +93,15 @@ public class AdapterView extends RecyclerView.Adapter<AdapterView.ViewHolder> {
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
             context = itemView.getContext();
-            videoFrame = (FrameLayout) itemView.findViewById(R.id.video_frame);
-            videoTitleText = (TextView) itemView.findViewById(R.id.video_title_text);
+            videoFrame = itemView.findViewById(R.id.video_frame);
+            videoTitleText = itemView.findViewById(R.id.video_title_text);
             videoView = new BrightcoveExoPlayerVideoView(context);
             videoFrame.addView(videoView);
             videoView.finishInitialization();
 
             EventEmitter eventEmitter = videoView.getEventEmitter();
-            eventEmitter.on(EventType.ENTER_FULL_SCREEN, new EventListener() {
-                @Override
-                public void processEvent(Event event) {
-                    //You can set listeners on each Video View
-                }
+            eventEmitter.on(EventType.ENTER_FULL_SCREEN, event -> {
+                // You can set listeners on each video view here.
             });
         }
     }

--- a/Player/VideoListSampleApp-java/src/main/res/values/strings.xml
+++ b/Player/VideoListSampleApp-java/src/main/res/values/strings.xml
@@ -6,9 +6,9 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
-    <!-- A sample Brightcove Video ID -->
+    <!-- A sample Brightcove playlist reference ID -->
     <string name="sdk_demo_playlist_reference">animal_videos</string>
 
     <string name="lorem_ipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>

--- a/Player/VideoListSampleApp-kotlin/README.md
+++ b/Player/VideoListSampleApp-kotlin/README.md
@@ -6,7 +6,7 @@ Shows multiple independent Brightcove player instances in a scrolling `RecyclerV
 
 | File | Responsibility |
 |---|---|
-| `VideoListSampleActivity.kt` | Fetches a playlist via `Catalog` and populates the RecyclerView. |
+| `MainActivity.kt` | Fetches a playlist via `Catalog` and populates the RecyclerView. |
 | `VideoListAdapter.kt` | `ListAdapter` with `DiffUtil`; builds a player per row and manages its playback lifecycle. |
 
 See the [Playback README](../) for shared setup and requirements.

--- a/Player/VideoListSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/Player/VideoListSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.videoList">
         <activity
-            android:name=".VideoListSampleActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/Player/VideoListSampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolist/kotlin/MainActivity.kt
+++ b/Player/VideoListSampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolist/kotlin/MainActivity.kt
@@ -11,7 +11,11 @@ import com.brightcove.player.event.EventEmitterImpl
 import com.brightcove.player.model.Playlist
 import com.brightcove.player.samples.videolist.kotlin.databinding.ActivityVideoListSampleBinding
 
-class VideoListSampleActivity : AppCompatActivity() {
+/**
+ * Fetches a Brightcove playlist and displays each video in a scrolling
+ * RecyclerView, with a dedicated player for every row.
+ */
+class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityVideoListSampleBinding
     private lateinit var videoListView: RecyclerView
@@ -25,14 +29,13 @@ class VideoListSampleActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         videoListView = binding.videoListView
-        videoListView.layoutManager =  LinearLayoutManager(this)
+        videoListView.layoutManager = LinearLayoutManager(this)
         adapter = VideoListAdapter()
 
         videoListView.adapter = adapter
 
         val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.sdk_demo_policy_key))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         catalog.findPlaylistByReferenceID(

--- a/Player/VideoListSampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolist/kotlin/VideoListAdapter.kt
+++ b/Player/VideoListSampleApp-kotlin/src/main/java/com/brightcove/player/samples/videolist/kotlin/VideoListAdapter.kt
@@ -22,7 +22,6 @@ class VideoListAdapter : ListAdapter<Video, VideoListAdapter.ViewHolder>(DIFF_CA
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        //Get Video information
         val video = getItem(position)
         holder.video = video
         holder.binding.videoTitleText.text = video.getStringProperty(Video.Fields.NAME)
@@ -55,8 +54,7 @@ class VideoListAdapter : ListAdapter<Video, VideoListAdapter.ViewHolder>(DIFF_CA
         }
     }
 
-    class ViewHolder (val binding: ItemViewBinding
-    ) : RecyclerView.ViewHolder(binding.root) {
+    class ViewHolder(val binding: ItemViewBinding) : RecyclerView.ViewHolder(binding.root) {
 
         val videoView = BrightcoveExoPlayerVideoView(itemView.context)
         var video: Video? = null
@@ -67,7 +65,7 @@ class VideoListAdapter : ListAdapter<Video, VideoListAdapter.ViewHolder>(DIFF_CA
 
             val eventEmitter = videoView.eventEmitter
             eventEmitter.on(EventType.ENTER_FULL_SCREEN) {
-                //You can set listeners on each Video View
+                // You can set listeners on each video view here.
             }
         }
     }
@@ -78,7 +76,7 @@ class VideoListAdapter : ListAdapter<Video, VideoListAdapter.ViewHolder>(DIFF_CA
                 oldItem.id == newItem.id
 
             override fun areContentsTheSame(oldItem: Video, newItem: Video): Boolean =
-                oldItem.equals(newItem)
+                oldItem == newItem
         }
     }
 }

--- a/Player/VideoListSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/Player/VideoListSampleApp-kotlin/src/main/res/values/strings.xml
@@ -6,9 +6,9 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
+    <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
-    <!-- A sample Brightcove Video ID -->
+    <!-- A sample Brightcove playlist reference ID -->
     <string name="sdk_demo_playlist_reference">animal_videos</string>
 
     <string name="lorem_ipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>

--- a/PlayerUI/CustomizedControlsSampleApp-java/src/main/AndroidManifest.xml
+++ b/PlayerUI/CustomizedControlsSampleApp-java/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:label="@string/app_name"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.customizedcontrols.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/PlayerUI/CustomizedControlsSampleApp-java/src/main/java/com/brightcove/player/samples/customizedcontrols/java/MainActivity.java
+++ b/PlayerUI/CustomizedControlsSampleApp-java/src/main/java/com/brightcove/player/samples/customizedcontrols/java/MainActivity.java
@@ -1,39 +1,42 @@
 package com.brightcove.player.samples.customizedcontrols.java;
 
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
-import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
-import com.brightcove.player.event.EventListener;
 import com.brightcove.player.event.EventType;
 import com.brightcove.player.mediacontroller.BrightcoveMediaController;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BaseVideoView;
 import com.brightcove.player.view.BrightcovePlayer;
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.view.View;
+import android.util.Log;
 import android.widget.Button;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
 /**
  * This app illustrates how to customize the Android default media controller.
- *
- * @author Sergio Martinez
  */
 public class MainActivity extends BrightcovePlayer {
-    //This TTF font is included in the Brightcove SDK.
+
+    private static final String TAG = MainActivity.class.getSimpleName();
+
+    // This TTF font is included in the Brightcove SDK.
     public static final String FONT_AWESOME = "fontawesome-webfont.ttf";
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the BrightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.default_activity_main);
-        brightcoveVideoView = (BrightcoveExoPlayerVideoView) findViewById(R.id.brightcove_video_view);
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view);
         initMediaController(brightcoveVideoView);
         super.onCreate(savedInstanceState);
 
@@ -41,11 +44,10 @@ public class MainActivity extends BrightcovePlayer {
         String account = getString(R.string.sdk_demo_account);
 
         Catalog catalog = new Catalog.Builder(eventEmitter, account)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -53,6 +55,11 @@ public class MainActivity extends BrightcovePlayer {
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }
@@ -67,27 +74,17 @@ public class MainActivity extends BrightcovePlayer {
         initButtons(brightcoveVideoView);
 
         // This event is sent by the BrightcovePlayer Activity when the onConfigurationChanged has been called.
-        brightcoveVideoView.getEventEmitter().on(EventType.CONFIGURATION_CHANGED, new EventListener() {
-            @Override
-            public void processEvent(Event event) {
-                initButtons(brightcoveVideoView);
-            }
-        });
+        brightcoveVideoView.getEventEmitter().on(EventType.CONFIGURATION_CHANGED, event -> initButtons(brightcoveVideoView));
     }
 
     private void initButtons(final BaseVideoView brightcoveVideoView) {
         Typeface font = Typeface.createFromAsset(this.getAssets(), FONT_AWESOME);
-        Button thumbsUp = (Button) brightcoveVideoView.findViewById(R.id.thumbs_up);
+        Button thumbsUp = brightcoveVideoView.findViewById(R.id.thumbs_up);
         if (thumbsUp != null) {
             // By setting this type face, we can use the symbols(icons) present in the font awesome file.
             thumbsUp.setTypeface(font);
+            thumbsUp.setOnClickListener(v -> Toast.makeText(MainActivity.this, "TEST", Toast.LENGTH_SHORT).show());
         }
-        thumbsUp.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Toast.makeText(MainActivity.this, "TEST", Toast.LENGTH_SHORT).show();
-            }
-        });
     }
 
 }

--- a/PlayerUI/CustomizedControlsSampleApp-java/src/main/res/values/strings.xml
+++ b/PlayerUI/CustomizedControlsSampleApp-java/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
     <!-- Below are hex strings taken from the fontawesome-webfont.ttf used in the Brightcove SDK -->
     <string name="brightcove_controls_rewind">&#xf04a;</string>

--- a/PlayerUI/CustomizedControlsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/customizedcontrols/kotlin/MainActivity.kt
+++ b/PlayerUI/CustomizedControlsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/customizedcontrols/kotlin/MainActivity.kt
@@ -2,15 +2,16 @@ package com.brightcove.player.samples.customizedcontrols.kotlin
 
 import android.graphics.Typeface
 import android.os.Bundle
+import android.util.Log
 import android.widget.Button
 import android.widget.Toast
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.EventType
 import com.brightcove.player.mediacontroller.BrightcoveMediaController
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BaseVideoView
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 
 /**
@@ -24,19 +25,22 @@ class MainActivity : BrightcovePlayer() {
         // When extending the BrightcovePlayer, we must assign brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle management.
         setContentView(R.layout.default_activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         initMediaController(brightcoveVideoView)
         super.onCreate(savedInstanceState)
 
         val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
     }
@@ -68,5 +72,7 @@ class MainActivity : BrightcovePlayer() {
     companion object {
         // This TTF font is included in the Brightcove SDK.
         private const val FONT_AWESOME = "fontawesome-webfont.ttf"
+
+        private const val TAG = "MainActivity"
     }
 }

--- a/PlayerUI/CustomizedControlsSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/PlayerUI/CustomizedControlsSampleApp-kotlin/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
     <!-- Below are hex strings taken from the fontawesome-webfont.ttf used in the Brightcove SDK -->
     <string name="brightcove_controls_rewind">&#xf04a;</string>

--- a/PlayerUI/RewindSampleApp-java/src/main/java/com/brightcove/player/samples/rewind/java/MainActivity.java
+++ b/PlayerUI/RewindSampleApp-java/src/main/java/com/brightcove/player/samples/rewind/java/MainActivity.java
@@ -1,24 +1,30 @@
 package com.brightcove.player.samples.rewind.java;
 
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
 
-import android.os.Bundle;
+import java.util.List;
 
 /**
  * This app illustrates customizing the rewind button glyph using the Brightcove media controller.  The code for the
  * rewind button glyph is a customizable resource.  See res/values/strings.xml for the gory detail.
- *
- * @author Paul Michael Reilly
  */
 public class MainActivity extends BrightcovePlayer {
+
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the BrightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.default_activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
@@ -28,7 +34,7 @@ public class MainActivity extends BrightcovePlayer {
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -36,6 +42,11 @@ public class MainActivity extends BrightcovePlayer {
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/PlayerUI/RewindSampleApp-java/src/main/res/values/strings.xml
+++ b/PlayerUI/RewindSampleApp-java/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
     <!-- The rewind button glyph is a customizable resource. Set it to any Font Awesome
          icon codepoint. Common choices:

--- a/PlayerUI/RewindSampleApp-kotlin/src/main/java/com/brightcove/player/samples/rewind/kotlin/MainActivity.kt
+++ b/PlayerUI/RewindSampleApp-kotlin/src/main/java/com/brightcove/player/samples/rewind/kotlin/MainActivity.kt
@@ -1,10 +1,11 @@
 package com.brightcove.player.samples.rewind.kotlin
 
 import android.os.Bundle
+import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 
 /**
@@ -17,18 +18,26 @@ class MainActivity : BrightcovePlayer() {
         // When extending the BrightcovePlayer, we must assign brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle management.
         setContentView(R.layout.default_activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/PlayerUI/RewindSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/PlayerUI/RewindSampleApp-kotlin/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
     <!-- The rewind button glyph is a customizable resource. Set it to any Font Awesome
          icon codepoint. Common choices:

--- a/PlayerUI/SeekBarColorsSampleApp-java/src/main/java/com/brightcove/player/samples/seekbarcolors/java/MainActivity.java
+++ b/PlayerUI/SeekBarColorsSampleApp-java/src/main/java/com/brightcove/player/samples/seekbarcolors/java/MainActivity.java
@@ -1,23 +1,30 @@
 package com.brightcove.player.samples.seekbarcolors.java;
 
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
 
-import android.os.Bundle;
+import java.util.List;
 
 /**
- * This app illustrates the basic behavior of the Android default media controller.
- *
- * @author Paul Michael Reilly
+ * This app illustrates recoloring the Android default media controller's seek bar. The
+ * customization is entirely in res/values/colors.xml (the bmc_seekbar_* colors).
  */
 public class MainActivity extends BrightcovePlayer {
 
+    private static final String TAG = MainActivity.class.getSimpleName();
+
     @Override protected void onCreate(Bundle savedInstanceState) {
-        // When extending the BrightcovePlayer, we must assign the BrightcoveVideoView before
+        // When extending the BrightcovePlayer, we must assign the brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.default_activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
@@ -27,7 +34,7 @@ public class MainActivity extends BrightcovePlayer {
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -35,6 +42,11 @@ public class MainActivity extends BrightcovePlayer {
             public void onVideo(Video video) {
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/PlayerUI/SeekBarColorsSampleApp-java/src/main/res/values/strings.xml
+++ b/PlayerUI/SeekBarColorsSampleApp-java/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/PlayerUI/SeekBarColorsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/seekbarcolors/kotlin/MainActivity.kt
+++ b/PlayerUI/SeekBarColorsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/seekbarcolors/kotlin/MainActivity.kt
@@ -1,10 +1,11 @@
 package com.brightcove.player.samples.seekbarcolors.kotlin
 
 import android.os.Bundle
+import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 
 /**
@@ -17,18 +18,26 @@ class MainActivity : BrightcovePlayer() {
         // When extending the BrightcovePlayer, we must assign brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle management.
         setContentView(R.layout.default_activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/PlayerUI/SeekBarColorsSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/PlayerUI/SeekBarColorsSampleApp-kotlin/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/PlayerUI/StyledControlsSampleApp-java/src/main/AndroidManifest.xml
+++ b/PlayerUI/StyledControlsSampleApp-java/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:label="@string/app_name"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="com.brightcove.player.samples.styledcontrols.java.MainActivity"
+            android:name=".MainActivity"
             android:screenOrientation="unspecified"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"

--- a/PlayerUI/StyledControlsSampleApp-java/src/main/java/com/brightcove/player/samples/styledcontrols/java/MainActivity.java
+++ b/PlayerUI/StyledControlsSampleApp-java/src/main/java/com/brightcove/player/samples/styledcontrols/java/MainActivity.java
@@ -1,29 +1,30 @@
 package com.brightcove.player.samples.styledcontrols.java;
 
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
 
-import android.os.Bundle;
-import android.util.Log;
+import java.util.List;
 
 /**
  * This app illustrates how to style the Android default media controller.
- *
- * @author Sergio Martinez
  */
 public class MainActivity extends BrightcovePlayer {
 
-    // Private class constants
-
-    private final String TAG = this.getClass().getSimpleName();
+    private static final String TAG = MainActivity.class.getSimpleName();
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         // When extending the BrightcovePlayer, we must assign the BrightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle
-        // management.  Establish the video object and use it's event emitter to get important
+        // management.  Establish the video object and use its event emitter to get important
         // notifications and to control logging.
         setContentView(R.layout.default_activity_main);
         brightcoveVideoView = findViewById(R.id.brightcove_video_view);
@@ -33,11 +34,10 @@ public class MainActivity extends BrightcovePlayer {
         String account = getString(R.string.sdk_demo_account);
 
         Catalog catalog = new Catalog.Builder(eventEmitter, account)
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
                 .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), new VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), new VideoListener() {
 
             // Add the video found to the queue with add().
             // Start playback of the video with start().
@@ -46,6 +46,11 @@ public class MainActivity extends BrightcovePlayer {
                 Log.v(TAG, "onVideo: video = " + video);
                 brightcoveVideoView.add(video);
                 brightcoveVideoView.start();
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }

--- a/PlayerUI/StyledControlsSampleApp-java/src/main/res/values/strings.xml
+++ b/PlayerUI/StyledControlsSampleApp-java/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/PlayerUI/StyledControlsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/styledcontrols/kotlin/MainActivity.kt
+++ b/PlayerUI/StyledControlsSampleApp-kotlin/src/main/java/com/brightcove/player/samples/styledcontrols/kotlin/MainActivity.kt
@@ -3,9 +3,9 @@ package com.brightcove.player.samples.styledcontrols.kotlin
 import android.os.Bundle
 import android.util.Log
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.model.Video
-import com.brightcove.player.view.BrightcoveExoPlayerVideoView
 import com.brightcove.player.view.BrightcovePlayer
 
 /**
@@ -14,26 +14,31 @@ import com.brightcove.player.view.BrightcovePlayer
  */
 class MainActivity : BrightcovePlayer() {
 
-    private val tag = this.javaClass.simpleName
-
     override fun onCreate(savedInstanceState: Bundle?) {
         // When extending the BrightcovePlayer, we must assign brightcoveVideoView before
         // entering the superclass. This allows for some stock video player lifecycle management.
         setContentView(R.layout.default_activity_main)
-        brightcoveVideoView = findViewById<BrightcoveExoPlayerVideoView>(R.id.brightcove_video_view)
+        brightcoveVideoView = findViewById(R.id.brightcove_video_view)
         super.onCreate(savedInstanceState)
 
         val catalog = Catalog.Builder(brightcoveVideoView.eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
             .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
-        catalog.findVideoByID(getString(R.string.sdk_demo_videoId), object : VideoListener() {
+        catalog.findVideoByID(getString(R.string.sdk_demo_video_id), object : VideoListener() {
             override fun onVideo(video: Video) {
-                Log.v(tag, "onVideo: video = $video")
+                Log.v(TAG, "onVideo: video = $video")
                 brightcoveVideoView.add(video)
                 brightcoveVideoView.start()
             }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
+            }
         })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/PlayerUI/StyledControlsSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/PlayerUI/StyledControlsSampleApp-kotlin/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="sdk_demo_policy">BCpkADawqM1RJu5c_I13hBUAi4c8QNWO5QN2yrd_OgDjTCVsbILeGDxbYy6xhZESTFi68MiSUHzMbQbuLV3q-gvZkJFpym1qYbEwogOqKCXK622KNLPF92tX8AY9a1cVVYCgxSPN12pPAuIM</string>
 
     <!-- A sample Brightcove Video ID -->
-    <string name="sdk_demo_videoId">5421538222001</string>
+    <string name="sdk_demo_video_id">5421538222001</string>
 
 </resources>

--- a/SSAI/BasicSsaiPALSampleApp-java/src/main/AndroidManifest.xml
+++ b/SSAI/BasicSsaiPALSampleApp-java/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:usesCleartextTraffic="true">
 
         <activity
-            android:name="com.brightcove.player.samples.basicssaipal.java.MainActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
             android:theme="@style/AppTheme">

--- a/SSAI/BasicSsaiPALSampleApp-java/src/main/java/com/brightcove/player/samples/basicssaipal/java/MainActivity.java
+++ b/SSAI/BasicSsaiPALSampleApp-java/src/main/java/com/brightcove/player/samples/basicssaipal/java/MainActivity.java
@@ -1,26 +1,22 @@
 package com.brightcove.player.samples.basicssaipal.java;
 
-import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SwitchCompat;
 
 import com.brightcove.player.Sdk;
 import com.brightcove.player.appcompat.BrightcovePlayerActivity;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
-import com.brightcove.player.event.Event;
 import com.brightcove.player.event.EventEmitter;
-import com.brightcove.player.event.EventListener;
 import com.brightcove.player.event.EventType;
 import com.brightcove.player.model.Video;
 import com.brightcove.player.network.HttpRequestConfig;
-import com.brightcove.player.samples.basicssaipal.java.R;
 import com.brightcove.ssai.SSAIComponent;
 import com.brightcove.ssai.event.SSAIEventType;
 import com.brightcove.ssai.omid.AdEventType;
@@ -33,13 +29,16 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.iab.omid.library.brightcove.adsession.FriendlyObstructionPurpose;
 
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+/**
+ * This app demonstrates server-side ad insertion (SSAI) combined with the Google PAL
+ * (Programmatic Access Library) nonce for ad tracking.
+ */
 public class MainActivity extends BrightcovePlayerActivity {
 
-    private static final String TAG = "MainActivity";
-    private static final String AD_CONFIG_ID_QUERY_PARAM_VALUE = "ba5e4879-77f0-424b-8c98-706ae5ad7eec";
+    private static final String TAG = MainActivity.class.getSimpleName();
     private static final String PARTNER_NAME = "dummyVendor";
     private static final String PARTNER_VERSION = Sdk.getVersionName();
 
@@ -66,24 +65,21 @@ public class MainActivity extends BrightcovePlayerActivity {
         // getConsentToStorage() method is a placeholder for the publisher's own
         // method of obtaining user consent, either by integrating with a CMP or
         // based on other methods the publisher chooses to handle storage consent.
-        //boolean isConsentToStorage = getConsentToStorage();
         consentSettings = ConsentSettings.builder()
                 .allowStorage(false)
                 .build();
         // It is important to instantiate the NonceLoader as early as possible to
         // allow it to initialize and preload data for a faster experience when
         // loading the NonceManager. A new NonceLoader will need to be instantiated
-        //if the ConsentSettings change for the user.
+        // if the ConsentSettings change for the user.
         nonceLoader = new NonceLoader(this, consentSettings);
 
-        //PAL
         generateNonceForAdRequest();
 
         final EventEmitter eventEmitter = baseVideoView.getEventEmitter();
 
         catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.sdk_demo_policy_key))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
 
         // Setup the error event handler for the SSAI plugin.
@@ -93,7 +89,6 @@ public class MainActivity extends BrightcovePlayerActivity {
         ssaiPlugin = new SSAIComponent(this, baseVideoView);
         View view = findViewById(R.id.ad_frame);
         if (view instanceof ViewGroup) {
-            // Set the companion ad container,
             ssaiPlugin.addCompanionContainer((ViewGroup) view);
         }
 
@@ -116,14 +111,10 @@ public class MainActivity extends BrightcovePlayerActivity {
         }
     }
 
-
     public void generateNonceForAdRequest() {
-        Set supportedApiFrameWorksSet = new HashSet();
         // The values 2, 7, and 9 correspond to player support for VPAID 2.0,
         // OMID 1.0, and SIMID 1.1.
-        supportedApiFrameWorksSet.add(2);
-        supportedApiFrameWorksSet.add(7);
-        supportedApiFrameWorksSet.add(9);
+        Set<Integer> supportedApiFrameWorksSet = Set.of(2, 7, 9);
 
         NonceRequest nonceRequest = NonceRequest.builder()
                 .descriptionURL("https://example.com/content1")
@@ -153,11 +144,11 @@ public class MainActivity extends BrightcovePlayerActivity {
             nonceManager = manager;
             String nonceString = manager.getNonce();
             ssaiPlugin.setNonce(nonceString);
-            Log.d("PALSample", "Generated nonce: " + nonceString);
+            Log.d(TAG, "Generated nonce: " + nonceString);
             // Set the HttpRequestConfig with the Ad Config Id configured in
             // your https://studio.brightcove.com account.
             HttpRequestConfig httpRequestConfig = new HttpRequestConfig.Builder()
-                    .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, AD_CONFIG_ID_QUERY_PARAM_VALUE)
+                    .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, getString(R.string.sdk_demo_ad_config_id))
                     .build();
 
             catalog.findVideoByID(getString(R.string.sdk_demo_video_id), httpRequestConfig, new VideoListener() {
@@ -168,12 +159,17 @@ public class MainActivity extends BrightcovePlayerActivity {
                     // an EventType.ERROR event will be emitted.
                     ssaiPlugin.processVideo(video);
                 }
+
+                @Override
+                public void onError(@NonNull List<CatalogError> errors) {
+                    Log.e(TAG, errors.toString());
+                }
             });
         }
 
         @Override
         public void onFailure(Exception error) {
-            Log.e("PALSample", "Nonce generation failed: " + error.getMessage());
+            Log.e(TAG, "Nonce generation failed: " + error.getMessage());
         }
     }
 

--- a/SSAI/BasicSsaiPALSampleApp-java/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiPALSampleApp-java/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Application name -->
-    <string name="app_name">BasicSsaiSampleApp</string>
+    <string name="app_name">BasicSsaiPALSampleApp</string>
 
     <!-- A sample Brightcove Edge Account ID -->
     <string name="sdk_demo_account">5420904993001</string>

--- a/SSAI/BasicSsaiPALSampleApp-java/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiPALSampleApp-java/src/main/res/values/strings.xml
@@ -6,10 +6,13 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
+    <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
     <string name="sdk_demo_video_id">6031901107001</string>
+
+    <!-- A sample Brightcove SSAI Ad Config ID -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
     <string name="toggle_open_measurement">Open Measurement</string>
 
 </resources>

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/README.md
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/README.md
@@ -6,6 +6,6 @@ Combines Brightcove server-side ad insertion with the Google PAL (Programmatic A
 
 | File | Responsibility |
 |---|---|
-| `BasicSsaiPALSampleAppActivity.kt` | Generates a PAL nonce via `NonceLoader`/`NonceManager`, passes it to the `SSAIComponent`, and loads a video by ID with an Ad Config ID for ad stitching. Forwards playback-start, playback-end, and ad-click signals to PAL, and wires an Open Measurement toggle. |
+| `MainActivity.kt` | Generates a PAL nonce via `NonceLoader`/`NonceManager`, passes it to the `SSAIComponent`, and loads a video by ID with an Ad Config ID for ad stitching. Forwards playback-start, playback-end, and ad-click signals to PAL, and wires an Open Measurement toggle. |
 
 See the [SSAI README](../) for shared setup and requirements.

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Base.Theme.BasicSsaiSample">
         <activity
-            android:name=".BasicSsaiPALSampleAppActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicssaipal/kotlin/MainActivity.kt
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicssaipal/kotlin/MainActivity.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.brightcove.player.Sdk
 import com.brightcove.player.appcompat.BrightcovePlayerActivity
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.Event
 import com.brightcove.player.event.EventType
@@ -21,8 +22,11 @@ import com.google.ads.interactivemedia.pal.NonceManager
 import com.google.ads.interactivemedia.pal.NonceRequest
 import com.iab.omid.library.brightcove.adsession.FriendlyObstructionPurpose
 
-
-class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
+/**
+ * This app demonstrates server-side ad insertion (SSAI) combined with the Google PAL
+ * (Programmatic Access Library) nonce for ad tracking.
+ */
+class MainActivity : BrightcovePlayerActivity() {
 
     private var plugin: SSAIComponent? = null
     private var tracker: OpenMeasurementTracker? = null
@@ -45,21 +49,19 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
 
         val eventEmitter = baseVideoView.eventEmitter
 
-        //PAL
         // The default value for allowStorage() is false, but can be
         // changed once the appropriate consent has been gathered. The
         // getConsentToStorage() method is a placeholder for the publisher's own
         // method of obtaining user consent, either by integrating with a CMP or
         // based on other methods the publisher chooses to handle storage consent.
-        //boolean isConsentToStorage = getConsentToStorage();
-        consentSettings = ConsentSettings.builder().allowStorage(false).build()
+        val settings = ConsentSettings.builder().allowStorage(false).build()
+        consentSettings = settings
 
         // It is important to instantiate the NonceLoader as early as possible to
         // allow it to initialize and preload data for a faster experience when
         // loading the NonceManager. A new NonceLoader will need to be instantiated
-        //if the ConsentSettings change for the user.
-
-        nonceLoader = NonceLoader( this, consentSettings!!)
+        // if the ConsentSettings change for the user.
+        nonceLoader = NonceLoader(this, settings)
 
         generateNonceForAdRequest()
 
@@ -70,8 +72,7 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
         eventEmitter.on(SSAIEventType.AD_CLICKED) { sendAdClick() }
 
         catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.sdk_demo_policy_key))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         // Setup the error event handler for the SSAI plugin.
@@ -84,12 +85,9 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
     }
 
     private fun generateNonceForAdRequest() {
-        val supportedApiFrameWorksSet: MutableSet<Int> = HashSet()
         // The values 2, 7, and 9 correspond to player support for
         // VPAID 2.0, OMID 1.0, and SIMID 1.1.
-        supportedApiFrameWorksSet.add(2)
-        supportedApiFrameWorksSet.add(7)
-        supportedApiFrameWorksSet.add(9)
+        val supportedApiFrameWorksSet = mutableSetOf(2, 7, 9)
 
         val nonceRequest = NonceRequest.builder()
             .descriptionURL("https://example.com/content1")
@@ -111,13 +109,13 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
             nonceManager = manager
             val nonceString = manager?.nonce
             plugin?.setNonce(nonceString)
-            Log.d("PALSample", "Generated nonce: $nonceString")
+            Log.d(TAG, "Generated nonce: $nonceString")
             // Set the HttpRequestConfig with the Ad Config Id configured in
             // your https://studio.brightcove.com account.
             val httpRequestConfig = HttpRequestConfig.Builder()
                 .addQueryParameter(
                     HttpRequestConfig.KEY_AD_CONFIG_ID,
-                    AD_CONFIG_ID_QUERY_PARAM_VALUE
+                    getString(R.string.sdk_demo_ad_config_id)
                 )
                 .build()
 
@@ -131,33 +129,34 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
                         // an EventType.ERROR event will be emitted.
                         plugin?.processVideo(video)
                     }
+
+                    override fun onError(errors: List<CatalogError>) {
+                        Log.e(TAG, errors.toString())
+                    }
                 })
         }?.addOnFailureListener { error ->
-            Log.e("PALSample", "Nonce generation failed: " + error.message)
+            Log.e(TAG, "Nonce generation failed: ${error.message}")
         }
     }
 
     private fun sendAdClick() {
-        if (nonceManager != null) {
-            nonceManager?.sendAdClick()
-            Log.d(TAG,"PAL sendAdClick() called"
-            )
+        nonceManager?.let {
+            it.sendAdClick()
+            Log.d(TAG, "PAL sendAdClick() called")
         }
     }
 
     private fun sendPlaybackStart() {
-        if (nonceManager != null) {
-            nonceManager?.sendPlaybackStart()
-            Log.d(TAG,"PAL sendPlaybackStart() called"
-            )
+        nonceManager?.let {
+            it.sendPlaybackStart()
+            Log.d(TAG, "PAL sendPlaybackStart() called")
         }
     }
 
     private fun sendPlaybackEnd() {
-        if (nonceManager != null) {
-            nonceManager?.sendPlaybackEnd()
-            Log.d(TAG,"PAL sendPlaybackEnd() called"
-            )
+        nonceManager?.let {
+            it.sendPlaybackEnd()
+            Log.d(TAG, "PAL sendPlaybackEnd() called")
         }
     }
 
@@ -166,9 +165,7 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
         if (tracker != null && isFinishing) {
             tracker?.stop()
         }
-        if (nonceLoader != null) {
-            nonceLoader!!.release()
-        }
+        nonceLoader?.release()
     }
 
     private fun setupOpenMeasurement() {
@@ -218,7 +215,6 @@ class BasicSsaiPALSampleAppActivity : BrightcovePlayerActivity() {
 
     companion object {
         private const val TAG = "MainActivity"
-        private const val AD_CONFIG_ID_QUERY_PARAM_VALUE = "ba5e4879-77f0-424b-8c98-706ae5ad7eec"
         private const val PARTNER_NAME = "dummyVendor"
         private val PARTNER_VERSION = Sdk.getVersionName()
     }

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/layout/activity_basic_ssai_pal_sample.xml
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/layout/activity_basic_ssai_pal_sample.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical"
-    tools:context=".BasicSsaiPALSampleAppActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">BasicSsaiSampleApp</string>
+    <string name="app_name">BasicSsaiPALSampleApp</string>
 
     <!-- A sample Brightcove Edge Account ID -->
     <string name="sdk_demo_account">5420904993001</string>

--- a/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiPALSampleApp-kotlin/src/main/res/values/strings.xml
@@ -5,9 +5,12 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
+    <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
     <string name="sdk_demo_video_id">6031901107001</string>
+
+    <!-- A sample Brightcove SSAI Ad Config ID -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
     <string name="toggle_open_measurement">Open Measurement</string>
 </resources>

--- a/SSAI/BasicSsaiSampleApp-java/src/main/java/com/brightcove/player/samples/basicssai/java/MainActivity.java
+++ b/SSAI/BasicSsaiSampleApp-java/src/main/java/com/brightcove/player/samples/basicssai/java/MainActivity.java
@@ -5,11 +5,13 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SwitchCompat;
 
 import com.brightcove.player.Sdk;
 import com.brightcove.player.appcompat.BrightcovePlayerActivity;
 import com.brightcove.player.edge.Catalog;
+import com.brightcove.player.edge.CatalogError;
 import com.brightcove.player.edge.VideoListener;
 import com.brightcove.player.event.EventEmitter;
 import com.brightcove.player.event.EventType;
@@ -20,10 +22,15 @@ import com.brightcove.ssai.omid.AdEventType;
 import com.brightcove.ssai.omid.OpenMeasurementTracker;
 import com.iab.omid.library.brightcove.adsession.FriendlyObstructionPurpose;
 
+import java.util.List;
+
+/**
+ * This app demonstrates server-side ad insertion (SSAI) using the SSAIComponent
+ * plugin, including an optional Open Measurement tracker toggle.
+ */
 public class MainActivity extends BrightcovePlayerActivity {
 
-    private static final String TAG = "MainActivity";
-    private static final String AD_CONFIG_ID_QUERY_PARAM_VALUE = "ba5e4879-77f0-424b-8c98-706ae5ad7eec";
+    private static final String TAG = MainActivity.class.getSimpleName();
     private static final String PARTNER_NAME = "dummyVendor";
     private static final String PARTNER_VERSION = Sdk.getVersionName();
 
@@ -42,10 +49,8 @@ public class MainActivity extends BrightcovePlayerActivity {
         final EventEmitter eventEmitter = baseVideoView.getEventEmitter();
 
         Catalog catalog = new Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-                .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-                .setPolicy(getString(R.string.sdk_demo_policy_key))
+                .setPolicy(getString(R.string.sdk_demo_policy))
                 .build();
-
 
         // Setup the error event handler for the SSAI plugin.
         registerErrorEventHandler();
@@ -53,14 +58,13 @@ public class MainActivity extends BrightcovePlayerActivity {
         plugin = new SSAIComponent(this, baseVideoView);
         View view = findViewById(R.id.ad_frame);
         if (view instanceof ViewGroup) {
-            // Set the companion ad container,
             plugin.addCompanionContainer((ViewGroup) view);
         }
 
         // Set the HttpRequestConfig with the Ad Config Id configured in
         // your https://studio.brightcove.com account.
         HttpRequestConfig httpRequestConfig = new HttpRequestConfig.Builder()
-                .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, AD_CONFIG_ID_QUERY_PARAM_VALUE)
+                .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, getString(R.string.sdk_demo_ad_config_id))
                 .build();
 
         catalog.findVideoByID(getString(R.string.sdk_demo_video_id), httpRequestConfig, new VideoListener() {
@@ -70,6 +74,11 @@ public class MainActivity extends BrightcovePlayerActivity {
                 // If there is not a VMAP url, or if there are any requesting or parsing error,
                 // an EventType.ERROR event will be emitted.
                 plugin.processVideo(video);
+            }
+
+            @Override
+            public void onError(@NonNull List<CatalogError> errors) {
+                Log.e(TAG, errors.toString());
             }
         });
     }
@@ -91,7 +100,6 @@ public class MainActivity extends BrightcovePlayerActivity {
                 tracker.stop();
             }
         });
-        // Initialize the OpenMeasurementTracker
         tracker = new OpenMeasurementTracker.Factory(
                 PARTNER_NAME, PARTNER_VERSION, baseVideoView
         ).create();

--- a/SSAI/BasicSsaiSampleApp-java/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiSampleApp-java/src/main/res/values/strings.xml
@@ -6,10 +6,13 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
+    <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
     <string name="sdk_demo_video_id">6031901107001</string>
+
+    <!-- A sample Brightcove SSAI Ad Config ID -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
     <string name="toggle_open_measurement">Open Measurement</string>
 
 </resources>

--- a/SSAI/BasicSsaiSampleApp-kotlin/README.md
+++ b/SSAI/BasicSsaiSampleApp-kotlin/README.md
@@ -6,6 +6,6 @@ Plays a video with Brightcove server-side ad insertion using the SSAI plugin (`S
 
 | File | Responsibility |
 |---|---|
-| `BasicSsaiSampleAppActivity.kt` | Creates the `SSAIComponent`, registers the companion-ad container, loads a video by ID with an Ad Config ID query parameter through the `Catalog`, and hands the video to the plugin for ad stitching. Also wires an error handler and an Open Measurement tracker toggle. |
+| `MainActivity.kt` | Creates the `SSAIComponent`, registers the companion-ad container, loads a video by ID with an Ad Config ID query parameter through the `Catalog`, and hands the video to the plugin for ad stitching. Also wires an error handler and an Open Measurement tracker toggle. |
 
 See the [SSAI README](../) for shared setup and requirements.

--- a/SSAI/BasicSsaiSampleApp-kotlin/src/main/AndroidManifest.xml
+++ b/SSAI/BasicSsaiSampleApp-kotlin/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Base.Theme.BasicSsaiSample">
         <activity
-            android:name=".BasicSsaiSampleAppActivity"
+            android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>

--- a/SSAI/BasicSsaiSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicssai/kotlin/MainActivity.kt
+++ b/SSAI/BasicSsaiSampleApp-kotlin/src/main/java/com/brightcove/player/samples/basicssai/kotlin/MainActivity.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.brightcove.player.Sdk
 import com.brightcove.player.appcompat.BrightcovePlayerActivity
 import com.brightcove.player.edge.Catalog
+import com.brightcove.player.edge.CatalogError
 import com.brightcove.player.edge.VideoListener
 import com.brightcove.player.event.Event
 import com.brightcove.player.event.EventType
@@ -16,7 +17,11 @@ import com.brightcove.ssai.omid.OpenMeasurementTracker
 import com.brightcove.player.samples.basicssai.kotlin.databinding.ActivityBasicSsaiSampleBinding
 import com.iab.omid.library.brightcove.adsession.FriendlyObstructionPurpose
 
-class BasicSsaiSampleAppActivity : BrightcovePlayerActivity() {
+/**
+ * This app demonstrates server-side ad insertion (SSAI) using the SSAIComponent
+ * plugin, including an optional Open Measurement tracker toggle.
+ */
+class MainActivity : BrightcovePlayerActivity() {
 
     private var plugin: SSAIComponent? = null
     private var tracker: OpenMeasurementTracker? = null
@@ -34,22 +39,19 @@ class BasicSsaiSampleAppActivity : BrightcovePlayerActivity() {
 
         val eventEmitter = baseVideoView.eventEmitter
         val catalog = Catalog.Builder(eventEmitter, getString(R.string.sdk_demo_account))
-            .setBaseURL(Catalog.DEFAULT_EDGE_BASE_URL)
-            .setPolicy(getString(R.string.sdk_demo_policy_key))
+            .setPolicy(getString(R.string.sdk_demo_policy))
             .build()
 
         // Setup the error event handler for the SSAI plugin.
         registerErrorEventHandler()
         setupOpenMeasurement()
         plugin = SSAIComponent(this, baseVideoView)
-
-        // Set the companion ad container.
         plugin?.addCompanionContainer(binding.adFrame)
 
         // Set the HttpRequestConfig with the Ad Config Id configured in
         // your https://studio.brightcove.com account.
         val httpRequestConfig = HttpRequestConfig.Builder()
-            .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, AD_CONFIG_ID_QUERY_PARAM_VALUE)
+            .addQueryParameter(HttpRequestConfig.KEY_AD_CONFIG_ID, getString(R.string.sdk_demo_ad_config_id))
             .build()
 
         catalog.findVideoByID(getString(R.string.sdk_demo_video_id), httpRequestConfig, object : VideoListener() {
@@ -58,6 +60,10 @@ class BasicSsaiSampleAppActivity : BrightcovePlayerActivity() {
                 // If there is not a VMAP url, or if there are any requesting or parsing error,
                 // an EventType.ERROR event will be emitted.
                 plugin?.processVideo(video)
+            }
+
+            override fun onError(errors: List<CatalogError>) {
+                Log.e(TAG, errors.toString())
             }
         })
     }
@@ -78,7 +84,6 @@ class BasicSsaiSampleAppActivity : BrightcovePlayerActivity() {
             }
         }
 
-        // Initialize the OpenMeasurementTracker
         tracker = OpenMeasurementTracker.Factory(PARTNER_NAME, PARTNER_VERSION, baseVideoView).create()
 
         // NOTE: The ad used in the sample does not have an `AdVerification` element and will not
@@ -116,7 +121,6 @@ class BasicSsaiSampleAppActivity : BrightcovePlayerActivity() {
 
     companion object {
         private const val TAG = "MainActivity"
-        private const val AD_CONFIG_ID_QUERY_PARAM_VALUE = "ba5e4879-77f0-424b-8c98-706ae5ad7eec"
         private const val PARTNER_NAME = "dummyVendor"
         private val PARTNER_VERSION = Sdk.getVersionName()
     }

--- a/SSAI/BasicSsaiSampleApp-kotlin/src/main/res/layout/activity_basic_ssai_sample.xml
+++ b/SSAI/BasicSsaiSampleApp-kotlin/src/main/res/layout/activity_basic_ssai_sample.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical"
-    tools:context=".BasicSsaiSampleAppActivity">
+    tools:context=".MainActivity">
 
     <com.brightcove.player.view.BrightcoveExoPlayerVideoView
         android:id="@+id/brightcove_video_view"

--- a/SSAI/BasicSsaiSampleApp-kotlin/src/main/res/values/strings.xml
+++ b/SSAI/BasicSsaiSampleApp-kotlin/src/main/res/values/strings.xml
@@ -5,9 +5,12 @@
     <string name="sdk_demo_account">5420904993001</string>
 
     <!-- A sample Brightcove Edge Policy Key -->
-    <string name="sdk_demo_policy_key">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
+    <string name="sdk_demo_policy">BCpkADawqM3DwCTPGyMMiG0loem8lXox3utO1lFEP1i-_l1MpjRSVXMTSsa2ToslC129_W6YzwJpXbpbIVRFwf35qYM0pxo2HJK-_SotgmgrkmJTQ-024GkXIelVSY8LOHZzRBtcBU57M6Is</string>
 
     <!-- A sample Brightcove Video ID -->
     <string name="sdk_demo_video_id">6031901107001</string>
+
+    <!-- A sample Brightcove SSAI Ad Config ID -->
+    <string name="sdk_demo_ad_config_id">ba5e4879-77f0-424b-8c98-706ae5ad7eec</string>
     <string name="toggle_open_measurement">Open Measurement</string>
 </resources>


### PR DESCRIPTION
## Summary

A source-level cleanup pass over every sample app so the code reads as clear, consistent, idiomatic reference material. This follows the earlier structural/documentation reorganization (#322) and focuses on the code inside each sample — Java and Kotlin, each cleaned in its own idiom. Changes are deliberately low-risk and behavior-preserving; the only runtime-behavior changes are the handful of genuine bug fixes listed below.

Every sample was build-verified (`assembleDebug`) per module and the full project builds green.

## What changed (applied consistently across the samples)

- **Consistent naming** — every sample's launcher Activity is `MainActivity` and list adapters are `VideoListAdapter` (renames preserve git history; manifests, `tools:context`, and each sample's README "Key files" updated to match).
- **Consistent string resources** — account / policy / video keys unified to `sdk_demo_account` / `sdk_demo_policy` / `sdk_demo_video_id` (values unchanged); duplicated ad-config ids and ad-server URLs externalized to shared keys.
- **Docs & comments** — removed stale author tags, fixed typos/grammar, added a concise class doc where missing, and dropped comments that merely restated the next line.
- **Idioms** — one `TAG`/logging convention; `Catalog.Builder` in place of the deprecated 3-arg constructor; dropped redundant `findViewById` casts and the redundant `.setBaseURL(DEFAULT_EDGE_BASE_URL)`; a logging `onError` on catalog listeners; small Kotlin/Java idiom tidy-ups.
- **Dead code** — removed unused imports/fields, no-op overrides, and write-only structures.

## Bug fixes

A few genuine defects surfaced during the cleanup and are fixed here (behavior-preserving elsewhere):

- **Cast** — the video description was written to the duration row (and overwritten), so it never displayed; it now shows correctly, matching the Java variant.
- **Offline** — null-guarded the audio-role/audio/caption paths in `BrightcoveDownloadUtil` and made its "list changed" flag reflect an actual change.
- **AudioOnly (Java)** — stopped shadowing the inherited player-view field and restored the documented assign-before-`super.onCreate()` order; the swallowed media-load error now logs at error level.
- **Picture-in-Picture (Java)** — the settings Up button now navigates up instead of relaunching the settings screen.
- **AppCompat (Kotlin)** — `PlayerFragment` migrated to the AndroidX `BrightcovePlayerFragment`, matching the Java variant.
- **VideoList / VideoListAdRulesIMA (Java)** — corrected a misleading `@Nullable` on `setVideoList` to `@NonNull` (it dereferenced the list without a null check).

## Scope / notes

- Java and Kotlin remain feature-parallel, each idiomatic in its own language.
- No demo account, policy, video, or ad values were changed — only key names and code wiring.
- **Pulse** is not included (its build requires a FreeWheel/Pulse AAR that isn't available in this environment).
- Broader modernizations (ViewBinding conversion, `ListAdapter`/`DiffUtil`, further AndroidX migrations) are intentionally out of scope for this pass.