### PR TITLE
Pin the Kotlin JVM target to 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,16 @@ configure(sampleModules) {
     }
   }
 
+  // Kotlin samples: pin the Kotlin JVM target to match the Java 17 target above, so the build is
+  // consistent regardless of the JDK that runs Gradle (e.g. Android Studio's bundled JBR 21).
+  plugins.withId('org.jetbrains.kotlin.android') {
+    android {
+      kotlinOptions {
+        jvmTarget = '17'
+      }
+    }
+  }
+
   // Shared by every sample: the core SDK plus the ExoPlayer/Media3 playback backend.
   dependencies {
     implementation "com.brightcove.player:android-sdk:${anpVersion}"


### PR DESCRIPTION
## Problem

The build pins **Java** to 17 (`compileOptions { sourceCompatibility/targetCompatibility JavaVersion.VERSION_17 }`) but never pins the **Kotlin** `jvmTarget`. When the Kotlin target isn't set, it's inferred from whichever JDK runs Gradle:

- Building on **JDK 17** → Kotlin targets 17 → matches Java 17 → OK.
- Building on **JDK 21** (e.g. Android Studio's bundled **JBR 21**) → Kotlin targets 21 → mismatches Java 17 → the Kotlin plugin aborts:

  > Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21).

This surfaces only in Kotlin modules that don't already pin their own `jvmTarget`. Most modules set their own Kotlin target, so today the mismatch hits four of them: `DAI/BasicDAISampleApp-kotlin`, `IMA/VideoListAdRulesIMASampleApp-kotlin`, `Offline/OfflinePlaybackSampleApp-kotlin`, and `Player/ThumbnailScrubberSampleApp-kotlin`. A developer on a JDK 21 toolchain hits the build failure on those.

## Fix

Pin the Kotlin `jvmTarget` to 17 at the project level to match the Java target, so the build is consistent regardless of the launching JDK. The setting is gated on the `org.jetbrains.kotlin.android` plugin, so the Java-only samples are unaffected, and any module that already sets its own `jvmTarget` keeps it:

```gradle
plugins.withId('org.jetbrains.kotlin.android') {
  android {
    kotlinOptions {
      jvmTarget = '17'
    }
  }
}
```

## Verification

- All `-kotlin` and `-java` modules build green on JDK 17 (no regression; the Java-only modules are untouched by the gate).
- The pin is explicit, so Kotlin targets 17 regardless of the launching JDK, resolving the 17-vs-21 mismatch that a JDK 21 toolchain would otherwise trigger on the four unpinned modules.

Build-config only; no source or dependency changes.
